### PR TITLE
Kotlin/Spring correctness, DTO cleanup, error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-# Start the PostgreSQL database (required before running the app)
+# Full-stack (Dockerized) — builds and runs both postgres and the API
 docker-compose up -d
 
-# Run the application
+# Hybrid (local dev) — starts only the database; run the API separately
+docker-compose up -d postgres
 ./gradlew bootRun
 
 # Build
@@ -31,9 +32,11 @@ Copy `.env` values as environment variables before running. The app reads `POSTG
 export $(grep -v '^#' .env | xargs)
 ```
 
+Requires **Java 21** (the Gradle toolchain will download it automatically if not present).
+
 ## Architecture
 
-Kotlin + Spring Boot 3.5 REST API backed by PostgreSQL. Uses **Spring Data JDBC** (`JdbcTemplate`) with hand-written SQL — there is no JPA/ORM.
+Kotlin + Spring Boot 3.5 REST API backed by **PostgreSQL 16**. Uses **Spring Data JDBC** (`JdbcTemplate`) with hand-written SQL — there is no JPA/ORM.
 
 **Layer flow:** `Controller → Service → Repository`
 
@@ -41,7 +44,7 @@ Kotlin + Spring Boot 3.5 REST API backed by PostgreSQL. Uses **Spring Data JDBC*
 - `service/` — Business logic. Throws `NotFoundException` when entities are missing.
 - `repository/` — Raw SQL via `JdbcTemplate` with inline `RowMapper` lambdas. Uses `RETURNING` clauses on inserts to avoid a second query.
 - `model/` — Plain Kotlin data classes (no annotations). `id` and `createdAt` are nullable since they are DB-assigned.
-- `dto/` — Request/response classes. Requests use Bean Validation annotations (`@NotBlank`, `@Min`, etc.).
+- `dto/` — Request/response classes. Requests use Bean Validation annotations (`@NotBlank`, `@Min`, `@Email`, etc.). Required fields are non-nullable; optional fields are `String?`/`Int?`. Response DTOs use non-nullable types for fields guaranteed by the DB schema.
 - `mapper/` — Spring `@Component` classes that convert between `model` and `dto` types.
 - `exception/` — `GlobalExceptionHandler` (`@RestControllerAdvice`) centralises error responses. All 404s come from `NotFoundException`.
 
@@ -69,27 +72,42 @@ Kotlin + Spring Boot 3.5 REST API backed by PostgreSQL. Uses **Spring Data JDBC*
 | PUT | `/api/users/{userId}/ticks/{tickId}` | Update style/rating/personalNote |
 | DELETE | `/api/users/{userId}/ticks/{tickId}` | 204; 404 if not found |
 
-All error responses share the shape: `{ timestamp, status, error, message, path }`.
+All error responses share the shape: `{ timestamp, status, error, errorCode, message, path }`.
 
 ## Domain model
 
 ```
 climbing_areas
-    └── walls (FK: area_id)
-            └── routes (FK: wall_id)
+    └── walls (FK: area_id, ON DELETE CASCADE)
+            └── routes (FK: wall_id, ON DELETE CASCADE)
 
 users
-    └── user_route_ticks (FK: user_id, route_id)
+    └── user_route_ticks (FK: user_id + route_id, ON DELETE CASCADE, UNIQUE per pair)
 ```
 
-`ClimbingArea` has a controller/service/repository. `User` and `UserRoute` (ticks) are fully wired up. All five domain types now have a complete stack.
+All five domain types have a complete Controller/Service/Repository stack.
 
 ## Conventions
 
 - Services trim `name` (and `grade` for routes) before persisting.
 - Mappers only implement `toResponse()` — there is no `toModel()` direction.
-- Unit tests for `UserService` and `TickService` use Mockito (`@ExtendWith(MockitoExtension::class)`) — no Spring context needed.
+- Unit tests for `UserService` and `TickService` use Mockito (`@ExtendWith(MockitoExtension::class)`) with JUnit 5 — no Spring context needed.
+- All REST endpoints are prefixed with `/api`.
+- No authentication or authorisation is implemented yet.
+- Multi-step service methods (e.g. validate → insert) are annotated `@Transactional`.
 
 ## Database migrations
 
 Flyway migrations live in `src/main/resources/db/migration/`. New migrations must follow the `V{n}__{description}.sql` naming convention and are applied automatically on startup.
+
+| File | Purpose |
+|------|---------|
+| `V1__create_tables.sql` | Full schema (all 5 tables) |
+| `V2__seed_test_data.sql` | Sample wall + routes in Bergen |
+| `V3__seed_climbing_areas.sql` | Sample climbing areas + more walls/routes |
+| `V4__schema_improvements.sql` | NOT NULL on FK cols, UNIQUE on email + ticks, CASCADE deletes, FK indexes, lat/lng precision |
+
+## Related projects
+
+- **climbing-web** — companion frontend at https://github.com/585011/climbing-web.
+  `CorsConfig.kt` is wired for this frontend. API changes that affect the contract should be coordinated with that repo.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Climbing API
 
-REST API for managing climbing walls and routes.
+REST API for managing climbing walls, routes, and user ticks.
 
 ## Tech stack
 
@@ -18,41 +18,37 @@ REST API for managing climbing walls and routes.
 
 - JDK 21
 - Docker and Docker Compose
-- IntelliJ IDEA
 
 ## Quick start
 
-1. Copy `.env.example` to `.env` and fill in your local values
-2. Start the database: `docker-compose up -d`
-3. Configure datasource env vars in your IntelliJ Run Configuration (see [Environment variables](#environment-variables) below)
-4. Run `ClimbingProjectApplication` from IntelliJ
+```bash
+# Copy and fill in your local values
+cp .env.example .env
+
+# Full-stack: start postgres + build + run API
+docker-compose up -d
+
+# Or hybrid: start only the DB, run the API locally
+docker-compose up -d postgres
+export $(grep -v '^#' .env | xargs)
+./gradlew bootRun
+```
 
 The app runs at `http://localhost:8080`.  
 Swagger UI is available at `http://localhost:8080/swagger-ui.html`.
 
 ## Environment variables
 
-### Spring Boot
-
-The app reads its datasource configuration from environment variables. Set these in your IntelliJ **Run → Edit Configurations… → Environment variables**:
-
-| Variable | Example value |
-|---|---|
-| `SPRING_DATASOURCE_URL` | `jdbc:postgresql://localhost:5432/app` |
-| `SPRING_DATASOURCE_USERNAME` | `user` |
-| `SPRING_DATASOURCE_PASSWORD` | `password` |
-
-Spring Boot does **not** load `.env` automatically — the variables must be present in the process environment (i.e. set in the Run Configuration when running from IntelliJ).
-
-### Docker Compose
-
-`docker-compose.yml` reads a `.env` file from the project root to initialise the Postgres container. Copy `.env.example` to `.env` and set:
+`docker-compose.yml` reads `.env` from the project root automatically. For local `./gradlew bootRun`, export the variables into your shell first.
 
 | Variable | Description |
 |---|---|
 | `POSTGRES_DB` | Database name |
-| `POSTGRES_USER` | Postgres username |
-| `POSTGRES_PASSWORD` | Postgres password |
+| `POSTGRES_USER` | Postgres superuser (used by the postgres container init) |
+| `POSTGRES_PASSWORD` | Postgres superuser password |
+| `SPRING_DATASOURCE_USERNAME` | Username Spring Boot uses to connect |
+| `SPRING_DATASOURCE_PASSWORD` | Password Spring Boot uses to connect |
+| `SPRING_DATASOURCE_URL` | JDBC URL (only needed for local `bootRun`; compose overrides it) |
 
 ## Architecture
 
@@ -70,40 +66,53 @@ PostgreSQL
 
 **Key design decisions:**
 - No ORM — raw SQL with `RETURNING` clauses on INSERT/UPDATE to avoid a second query
-- All 404s are raised as `NotFoundException` and caught by `GlobalExceptionHandler` (`@RestControllerAdvice`)
+- All 404s raised as `NotFoundException`, caught by `GlobalExceptionHandler` (`@RestControllerAdvice`)
 - Mappers convert model → response DTO only (no reverse direction)
 - Services trim `name` (and `grade` for routes) before persisting
+- Multi-step service methods (validate → insert) are wrapped in `@Transactional`
 
 ## Domain model
 
 ```
 climbing_areas
-    └── walls          (FK: area_id → climbing_areas.id)
-            └── routes (FK: wall_id → walls.id)
+    └── walls          (FK: area_id → climbing_areas.id, CASCADE)
+            └── routes (FK: wall_id → walls.id, CASCADE)
 
 users
-    └── user_route_ticks (FK: user_id → users.id, route_id → routes.id)
+    └── user_route_ticks (FK: user_id → users.id, route_id → routes.id, CASCADE; UNIQUE per pair)
 ```
 
-`Wall` and `Route` are fully implemented. `ClimbingArea`, `User`, and `UserRoute` have models and DB tables but no controllers or services yet.
+Deleting a parent cascades to all children (area → walls → routes → ticks; user → ticks).
 
 ## API endpoints
 
 | Method | Path | Description | Success |
 |---|---|---|---|
+| GET | `/api/climbing-areas` | List all areas | 200 |
+| GET | `/api/climbing-areas/{id}` | Get area by ID | 200 / 404 |
+| POST | `/api/climbing-areas` | Create area | 201 |
+| PUT | `/api/climbing-areas/{id}` | Full replace | 200 / 404 |
 | GET | `/api/walls` | List all walls | 200 |
 | GET | `/api/walls/{id}` | Get wall by ID | 200 / 404 |
 | POST | `/api/walls` | Create wall | 201 |
 | PUT | `/api/walls/{id}` | Full replace | 200 / 404 |
-| DELETE | `/api/walls/{id}` | Delete wall | 204 / 404 |
 | GET | `/api/walls/{wallId}/routes` | List routes for a wall | 200 / 404 |
 | GET | `/api/routes` | List all routes | 200 |
 | GET | `/api/routes/{id}` | Get route by ID | 200 / 404 |
 | POST | `/api/routes` | Create route | 201 |
 | PUT | `/api/routes/{id}` | Full replace | 200 / 404 |
-| DELETE | `/api/routes/{id}` | Delete route | 204 / 404 |
+| GET | `/api/users` | List all users | 200 |
+| GET | `/api/users/{id}` | Get user by ID | 200 / 404 |
+| POST | `/api/users` | Create user | 201 |
+| PUT | `/api/users/{id}` | Full replace | 200 / 404 |
+| DELETE | `/api/users/{id}` | Delete user | 204 / 404 / 409 |
+| GET | `/api/users/{userId}/ticks` | List user's ticks | 200 / 404 |
+| POST | `/api/users/{userId}/ticks` | Tick a route | 201 / 404 / 409 |
+| GET | `/api/users/{userId}/ticks/{tickId}` | Get tick | 200 / 404 |
+| PUT | `/api/users/{userId}/ticks/{tickId}` | Update tick | 200 / 404 |
+| DELETE | `/api/users/{userId}/ticks/{tickId}` | Delete tick | 204 / 404 |
 
-All error responses share the shape: `{ timestamp, status, error, message, path }`.
+All error responses share the shape: `{ timestamp, status, error, errorCode, message, path }`.
 
 ## Database migrations
 
@@ -112,7 +121,9 @@ Flyway migrations live in `src/main/resources/db/migration/` and run automatical
 | File | Purpose |
 |---|---|
 | `V1__create_tables.sql` | Full schema (all 5 tables) |
-| `V2__seed_test_data.sql` | Sample data: 1 wall, 3 routes in Bergen |
+| `V2__seed_test_data.sql` | Sample wall + 3 routes in Bergen |
+| `V3__seed_climbing_areas.sql` | Sample climbing areas + more walls/routes |
+| `V4__schema_improvements.sql` | NOT NULL on FK cols, UNIQUE constraints, CASCADE deletes, FK indexes, lat/lng precision |
 
 New migrations must follow the `V{n}__{description}.sql` naming convention.
 
@@ -122,7 +133,7 @@ New migrations must follow the `V{n}__{description}.sql` naming convention.
 ./gradlew test
 ```
 
-Currently only a Spring context-load smoke test exists.
+Unit tests for `UserService` and `TickService` use Mockito (no Spring context). The context-load smoke test requires the database to be running.
 
 ## Building
 
@@ -130,4 +141,4 @@ Currently only a Spring context-load smoke test exists.
 ./gradlew build
 ```
 
-A `Dockerfile` is included for building a container image.
+A `Dockerfile` and `docker-compose.yml` are included for containerised builds and local development.

--- a/src/main/kotlin/com/example/climbingapi/dto/ClimbingAreaResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/ClimbingAreaResponse.kt
@@ -4,11 +4,11 @@ import java.math.BigDecimal
 import java.time.OffsetDateTime
 
 data class ClimbingAreaResponse(
-    val id: Int?,
-    val name: String?,
+    val id: Int,
+    val name: String,
     val description: String?,
     val latitude: BigDecimal?,
     val longitude: BigDecimal?,
     val region: String?,
-    val createdAt: OffsetDateTime?
+    val createdAt: OffsetDateTime
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateClimbingAreaRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateClimbingAreaRequest.kt
@@ -5,7 +5,7 @@ import java.math.BigDecimal
 
 data class CreateClimbingAreaRequest(
     @field:NotBlank(message = "name is required.")
-    val name: String?,
+    val name: String,
 
     val description: String?,
     val latitude: BigDecimal?,

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateRouteRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateRouteRequest.kt
@@ -1,16 +1,12 @@
 package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 
 data class CreateRouteRequest(
-    @field:NotNull(message = "wallId is required.")
     @field:Min(value = 1, message = "wallId must be at least 1.")
-    val wallId: Int?,
+    val wallId: Int,
 
     val name: String?,
-
     val grade: String?,
 
     @field:Min(value = 1, message = "length must be at least 1.")

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateTickRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateTickRequest.kt
@@ -2,10 +2,9 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotNull
 
 data class CreateTickRequest(
-    @field:NotNull @field:Min(1) val routeId: Int?,
+    @field:Min(1) val routeId: Int,
     val style: String?,
     @field:Min(1) @field:Max(5) val rating: Int?,
     val personalNote: String?

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateUserRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateUserRequest.kt
@@ -1,8 +1,9 @@
 package com.example.climbingapi.dto
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 
 data class CreateUserRequest(
-    @field:NotBlank val email: String?,
-    @field:NotBlank val displayName: String?
+    @field:NotBlank @field:Email val email: String,
+    @field:NotBlank val displayName: String
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateWallRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateWallRequest.kt
@@ -2,16 +2,14 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import java.math.BigDecimal
 
 data class CreateWallRequest(
-    @field:NotNull(message = "areaId is required.")
     @field:Min(value = 1, message = "areaId must be at least 1.")
-    val areaId: Int?,
+    val areaId: Int,
 
     @field:NotBlank(message = "name is required.")
-    val name: String?,
+    val name: String,
 
     val description: String?,
     val latitude: BigDecimal?,

--- a/src/main/kotlin/com/example/climbingapi/dto/RouteResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/RouteResponse.kt
@@ -3,8 +3,8 @@ package com.example.climbingapi.dto
 import java.time.OffsetDateTime
 
 data class RouteResponse(
-    val id: Int?,
-    val wallId: Int?,
+    val id: Int,
+    val wallId: Int,
     val name: String?,
     val grade: String?,
     val length: Int?,
@@ -13,5 +13,5 @@ data class RouteResponse(
     val ropeLengths: Int?,
     val firstAscendant: String?,
     val description: String?,
-    val createdAt: OffsetDateTime?
+    val createdAt: OffsetDateTime
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/TickResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/TickResponse.kt
@@ -3,10 +3,10 @@ package com.example.climbingapi.dto
 import java.time.OffsetDateTime
 
 data class TickResponse(
-    val id: Int?,
-    val userId: Int?,
-    val routeId: Int?,
-    val tickedAt: OffsetDateTime?,
+    val id: Int,
+    val userId: Int,
+    val routeId: Int,
+    val tickedAt: OffsetDateTime,
     val style: String?,
     val rating: Int?,
     val personalNote: String?

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateClimbingAreaRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateClimbingAreaRequest.kt
@@ -5,7 +5,7 @@ import java.math.BigDecimal
 
 data class UpdateClimbingAreaRequest(
     @field:NotBlank(message = "name is required.")
-    val name: String?,
+    val name: String,
 
     val description: String?,
     val latitude: BigDecimal?,

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateRouteRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateRouteRequest.kt
@@ -1,12 +1,10 @@
 package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotNull
 
 data class UpdateRouteRequest(
-    @field:NotNull(message = "wallId is required.")
     @field:Min(value = 1, message = "wallId must be at least 1.")
-    val wallId: Int?,
+    val wallId: Int,
 
     val name: String?,
     val grade: String?,

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateUserRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateUserRequest.kt
@@ -1,8 +1,9 @@
 package com.example.climbingapi.dto
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 
 data class UpdateUserRequest(
-    @field:NotBlank val email: String?,
-    @field:NotBlank val displayName: String?
+    @field:NotBlank @field:Email val email: String,
+    @field:NotBlank val displayName: String
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateWallRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateWallRequest.kt
@@ -2,16 +2,14 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import java.math.BigDecimal
 
 data class UpdateWallRequest(
-    @field:NotNull(message = "areaId is required.")
     @field:Min(value = 1, message = "areaId must be at least 1.")
-    val areaId: Int?,
+    val areaId: Int,
 
     @field:NotBlank(message = "name is required.")
-    val name: String?,
+    val name: String,
 
     val description: String?,
     val latitude: BigDecimal?,

--- a/src/main/kotlin/com/example/climbingapi/dto/UserResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UserResponse.kt
@@ -3,8 +3,8 @@ package com.example.climbingapi.dto
 import java.time.OffsetDateTime
 
 data class UserResponse(
-    val id: Int?,
-    val email: String?,
-    val displayName: String?,
-    val createdAt: OffsetDateTime?
+    val id: Int,
+    val email: String,
+    val displayName: String,
+    val createdAt: OffsetDateTime
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/WallResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/WallResponse.kt
@@ -4,12 +4,12 @@ import java.math.BigDecimal
 import java.time.OffsetDateTime
 
 data class WallResponse(
-    val id: Int?,
-    val areaId: Int?,
-    val name: String?,
+    val id: Int,
+    val areaId: Int,
+    val name: String,
     val description: String?,
     val latitude: BigDecimal?,
     val longitude: BigDecimal?,
     val approachInfo: String?,
-    val createdAt: OffsetDateTime?
+    val createdAt: OffsetDateTime
 )

--- a/src/main/kotlin/com/example/climbingapi/exception/ErrorResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/exception/ErrorResponse.kt
@@ -8,6 +8,7 @@ data class ErrorResponse(
     val timestamp: OffsetDateTime,
     val status: Int,
     val error: String,
+    val errorCode: String,
     val message: String,
     val path: String
 )

--- a/src/main/kotlin/com/example/climbingapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/climbingapi/exception/GlobalExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -17,7 +18,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException::class)
     fun handleNotFound(exception: NotFoundException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
-        return buildResponse(HttpStatus.NOT_FOUND, exception.message ?: "Not found", request)
+        return buildResponse(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.message ?: "Not found", request)
     }
 
     @ExceptionHandler(
@@ -28,29 +29,27 @@ class GlobalExceptionHandler {
     )
     fun handleBadRequest(exception: Exception, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         val message = extractBadRequestMessage(exception)
-        return buildResponse(HttpStatus.BAD_REQUEST, message, request)
+        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request)
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleMethodNotAllowed(exception: HttpRequestMethodNotSupportedException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
+        return buildResponse(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", exception.message ?: "Method not allowed", request)
     }
 
     @ExceptionHandler(DataIntegrityViolationException::class)
     fun handleConflict(exception: DataIntegrityViolationException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
-        return buildResponse(
-            HttpStatus.CONFLICT,
-            "Database constraint violation.",
-            request
-        )
+        return buildResponse(HttpStatus.CONFLICT, "CONFLICT", "Database constraint violation.", request)
     }
 
     @ExceptionHandler(Exception::class)
     fun handleUnexpected(exception: Exception, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
-        return buildResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "An unexpected error occurred.",
-            request
-        )
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "An unexpected error occurred.", request)
     }
 
     private fun buildResponse(
         status: HttpStatus,
+        errorCode: String,
         message: String,
         request: HttpServletRequest
     ): ResponseEntity<ErrorResponse> {
@@ -58,6 +57,7 @@ class GlobalExceptionHandler {
             timestamp = OffsetDateTime.now(),
             status = status.value(),
             error = status.reasonPhrase,
+            errorCode = errorCode,
             message = message,
             path = request.requestURI
         )
@@ -67,19 +67,13 @@ class GlobalExceptionHandler {
     private fun extractBadRequestMessage(exception: Exception): String {
         return when (exception) {
             is MethodArgumentNotValidException -> {
-                val fieldError: FieldError? = exception.bindingResult.fieldError
-                if (fieldError != null) {
-                    "${fieldError.field}: ${fieldError.defaultMessage}"
-                } else {
-                    "Request validation failed."
+                exception.bindingResult.allErrors.joinToString("; ") { error ->
+                    if (error is FieldError) "${error.field}: ${error.defaultMessage}"
+                    else error.defaultMessage ?: "Invalid value"
                 }
             }
-            is MethodArgumentTypeMismatchException -> {
-                "Invalid value for parameter: ${exception.name}"
-            }
-            is HttpMessageNotReadableException -> {
-                "Request body is missing or invalid."
-            }
+            is MethodArgumentTypeMismatchException -> "Invalid value for parameter: ${exception.name}"
+            is HttpMessageNotReadableException -> "Request body is missing or invalid."
             else -> exception.message ?: "Bad request"
         }
     }

--- a/src/main/kotlin/com/example/climbingapi/mapper/ClimbingAreaMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/ClimbingAreaMapper.kt
@@ -9,13 +9,13 @@ class ClimbingAreaMapper {
 
     fun toResponse(area: ClimbingArea): ClimbingAreaResponse {
         return ClimbingAreaResponse(
-            id = area.id,
-            name = area.name,
+            id = area.id!!,
+            name = area.name!!,
             description = area.description,
             latitude = area.latitude,
             longitude = area.longitude,
             region = area.region,
-            createdAt = area.createdAt
+            createdAt = area.createdAt!!
         )
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/mapper/RouteMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/RouteMapper.kt
@@ -9,8 +9,8 @@ class RouteMapper {
 
     fun toResponse(route: Route): RouteResponse {
         return RouteResponse(
-            id = route.id,
-            wallId = route.wallId,
+            id = route.id!!,
+            wallId = route.wallId!!,
             name = route.name,
             grade = route.grade,
             length = route.length,
@@ -19,7 +19,7 @@ class RouteMapper {
             ropeLengths = route.ropeLengths,
             firstAscendant = route.firstAscendant,
             description = route.description,
-            createdAt = route.createdAt
+            createdAt = route.createdAt!!
         )
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/mapper/TickMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/TickMapper.kt
@@ -9,10 +9,10 @@ class TickMapper {
 
     fun toResponse(tick: UserRoute): TickResponse {
         return TickResponse(
-            id = tick.id,
-            userId = tick.userId,
-            routeId = tick.routeId,
-            tickedAt = tick.tickedAt,
+            id = tick.id!!,
+            userId = tick.userId!!,
+            routeId = tick.routeId!!,
+            tickedAt = tick.tickedAt!!,
             style = tick.style,
             rating = tick.rating,
             personalNote = tick.personalNote

--- a/src/main/kotlin/com/example/climbingapi/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/UserMapper.kt
@@ -9,10 +9,10 @@ class UserMapper {
 
     fun toResponse(user: User): UserResponse {
         return UserResponse(
-            id = user.id,
-            email = user.email,
-            displayName = user.displayName,
-            createdAt = user.createdAt
+            id = user.id!!,
+            email = user.email!!,
+            displayName = user.displayName!!,
+            createdAt = user.createdAt!!
         )
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/mapper/WallMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/WallMapper.kt
@@ -9,14 +9,14 @@ class WallMapper {
 
     fun toResponse(wall: Wall): WallResponse {
         return WallResponse(
-            id = wall.id,
-            areaId = wall.areaId,
-            name = wall.name,
+            id = wall.id!!,
+            areaId = wall.areaId!!,
+            name = wall.name!!,
             description = wall.description,
             latitude = wall.latitude,
             longitude = wall.longitude,
             approachInfo = wall.approachInfo,
-            createdAt = wall.createdAt
+            createdAt = wall.createdAt!!
         )
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/repository/ClimbingAreaRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/ClimbingAreaRepository.kt
@@ -105,7 +105,7 @@ class ClimbingAreaRepository (
             created_at
         """.trimIndent()
 
-        return jdbcTemplate.queryForObject(
+        return jdbcTemplate.query(
             sql,
             climbingAreaMapper,
             climbingArea.name,
@@ -113,6 +113,6 @@ class ClimbingAreaRepository (
             climbingArea.latitude,
             climbingArea.longitude,
             climbingArea.region
-        )!!
+        ).firstOrNull() ?: error("INSERT RETURNING returned no row")
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/repository/RouteRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/RouteRepository.kt
@@ -158,7 +158,7 @@ class RouteRepository(
                       description
         """.trimIndent()
 
-        return jdbcTemplate.queryForObject(
+        return jdbcTemplate.query(
             sql,
             routeRowMapper,
             route.wallId,
@@ -170,6 +170,6 @@ class RouteRepository(
             route.ropeLengths,
             route.firstAscendant,
             route.description
-        )!!
+        ).firstOrNull() ?: error("INSERT RETURNING returned no row")
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/repository/TickRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/TickRepository.kt
@@ -48,10 +48,10 @@ class TickRepository(
             VALUES (?, ?, ?, ?, ?)
             RETURNING id, user_id, route_id, ticked_at, style, rating, personal_note
         """.trimIndent()
-        return jdbcTemplate.queryForObject(
+        return jdbcTemplate.query(
             sql, tickRowMapper,
             tick.userId, tick.routeId, tick.style, tick.rating, tick.personalNote
-        )!!
+        ).firstOrNull() ?: error("INSERT RETURNING returned no row")
     }
 
     fun update(id: Int, tick: UserRoute): UserRoute? {

--- a/src/main/kotlin/com/example/climbingapi/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/UserRepository.kt
@@ -43,7 +43,8 @@ class UserRepository(
             VALUES (?, ?)
             RETURNING id, email, display_name, created_at
         """.trimIndent()
-        return jdbcTemplate.queryForObject(sql, userRowMapper, user.email, user.displayName)!!
+        return jdbcTemplate.query(sql, userRowMapper, user.email, user.displayName).firstOrNull()
+            ?: error("INSERT RETURNING returned no row")
     }
 
     fun update(id: Int, user: User): User? {

--- a/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
@@ -135,7 +135,7 @@ class WallRepository(
                       created_at
         """.trimIndent()
 
-        return jdbcTemplate.queryForObject(
+        return jdbcTemplate.query(
             sql,
             wallRowMapper,
             wall.areaId,
@@ -144,6 +144,6 @@ class WallRepository(
             wall.latitude,
             wall.longitude,
             wall.approachInfo
-        )!!
+        ).firstOrNull() ?: error("INSERT RETURNING returned no row")
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/service/RouteService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/RouteService.kt
@@ -7,6 +7,7 @@ import com.example.climbingapi.model.Route
 import com.example.climbingapi.repository.RouteRepository
 import com.example.climbingapi.repository.WallRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class RouteService(
@@ -31,8 +32,9 @@ class RouteService(
         if (!routeRepository.deleteById(id)) throw NotFoundException("Route not found: $id")
     }
 
+    @Transactional
     fun update(id: Int, request: UpdateRouteRequest): Route {
-        wallRepository.getById(request.wallId!!)
+        wallRepository.getById(request.wallId)
             ?: throw NotFoundException("Wall not found: ${request.wallId}")
         return routeRepository.update(id, Route(
             id = null,
@@ -49,8 +51,9 @@ class RouteService(
         )) ?: throw NotFoundException("Route not found: $id")
     }
 
+    @Transactional
     fun create(request: CreateRouteRequest): Route {
-        wallRepository.getById(request.wallId!!)
+        wallRepository.getById(request.wallId)
             ?: throw NotFoundException("Wall not found: ${request.wallId}")
 
         val route = Route(

--- a/src/main/kotlin/com/example/climbingapi/service/TickService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/TickService.kt
@@ -8,6 +8,7 @@ import com.example.climbingapi.repository.RouteRepository
 import com.example.climbingapi.repository.TickRepository
 import com.example.climbingapi.repository.UserRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TickService(
@@ -28,9 +29,10 @@ class TickService(
         return tick
     }
 
+    @Transactional
     fun create(userId: Int, request: CreateTickRequest): UserRoute {
         userRepository.getById(userId) ?: throw NotFoundException("User not found: $userId")
-        routeRepository.getById(request.routeId!!) ?: throw NotFoundException("Route not found: ${request.routeId}")
+        routeRepository.getById(request.routeId) ?: throw NotFoundException("Route not found: ${request.routeId}")
         return tickRepository.create(UserRoute(
             id = null,
             userId = userId,


### PR DESCRIPTION
## Summary

- Replace `queryForObject()!!` with `.query().firstOrNull()` in all 5 repositories
- Fix `String?` + `@NotBlank` contradiction in all request DTOs; add `@Email` on email fields
- Make response DTO fields non-nullable where the DB guarantees a value
- Add `@Transactional` to multi-step service methods
- Complete `GlobalExceptionHandler`: 405 handler, all field errors returned, `errorCode` on `ErrorResponse`
- Update `CLAUDE.md` and `README.md`

## Test plan

- [ ] `./gradlew test` passes (unit tests)
- [ ] `POST /api/users` with `"email": "notanemail"` returns 400 with `@Email` error
- [ ] `POST /api/users` with two missing fields returns 400 listing **both** errors
- [ ] `PATCH /api/users` returns 405 with `errorCode: "METHOD_NOT_ALLOWED"`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)