### PR TITLE
feat: pagination, HikariCP config, CORS headers, service unit tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,21 +52,22 @@ Kotlin + Spring Boot 3.5 REST API backed by **PostgreSQL 16**. Uses **Spring Dat
 
 | Method | Path | Notes |
 |--------|------|-------|
-| GET | `/api/walls` | List all walls |
+| GET | `/api/climbing-areas` | List all areas; supports `?page=0&size=20` (max 100) |
+| GET | `/api/walls` | List all walls; supports `?page=0&size=20` (max 100) |
 | GET | `/api/walls/{id}` | 404 if not found |
 | POST | `/api/walls` | Returns 201; `areaId` required |
 | GET | `/api/walls/{wallId}/routes` | 404 if wall not found |
 | PUT | `/api/walls/{id}` | Full replace; 404 if not found |
-| GET | `/api/routes` | List all routes |
+| GET | `/api/routes` | List all routes; supports `?page=0&size=20` (max 100) |
 | GET | `/api/routes/{id}` | 404 if not found |
 | POST | `/api/routes` | Returns 201; validates wall exists |
 | PUT | `/api/routes/{id}` | Full replace; validates wall exists; 404 if not found |
-| GET | `/api/users` | List all users |
+| GET | `/api/users` | List all users; supports `?page=0&size=20` (max 100) |
 | GET | `/api/users/{id}` | 404 if not found |
 | POST | `/api/users` | Returns 201 |
 | PUT | `/api/users/{id}` | Full replace; 404 if not found |
 | DELETE | `/api/users/{id}` | 204; 409 if user has ticks |
-| GET | `/api/users/{userId}/ticks` | List user's ticked routes; 404 if user not found |
+| GET | `/api/users/{userId}/ticks` | List user's ticked routes; supports `?page=0&size=20`; 404 if user not found |
 | POST | `/api/users/{userId}/ticks` | Returns 201; validates user + route exist |
 | GET | `/api/users/{userId}/ticks/{tickId}` | 404 if user or tick not found |
 | PUT | `/api/users/{userId}/ticks/{tickId}` | Update style/rating/personalNote |
@@ -91,10 +92,11 @@ All five domain types have a complete Controller/Service/Repository stack.
 
 - Services trim `name` (and `grade` for routes) before persisting.
 - Mappers only implement `toResponse()` — there is no `toModel()` direction.
-- Unit tests for `UserService` and `TickService` use Mockito (`@ExtendWith(MockitoExtension::class)`) with JUnit 5 — no Spring context needed.
+- Unit tests for all 5 services use Mockito (`@ExtendWith(MockitoExtension::class)`) — no Spring context needed.
 - All REST endpoints are prefixed with `/api`.
 - No authentication or authorisation is implemented yet.
 - Multi-step service methods (e.g. validate → insert) are annotated `@Transactional`.
+- List endpoints return `PagedResponse<T>` with `data`, `page`, `pageSize`, `total` fields. Size is clamped to max 100 in the service layer.
 
 ## Database migrations
 

--- a/src/main/kotlin/com/example/climbingapi/config/CorsConfig.kt
+++ b/src/main/kotlin/com/example/climbingapi/config/CorsConfig.kt
@@ -10,5 +10,7 @@ class CorsConfig : WebMvcConfigurer {
         registry.addMapping("/api/**")
             .allowedOrigins("http://localhost:5173")
             .allowedMethods("GET", "POST", "PUT", "DELETE")
+            .allowedHeaders("*")
+            .maxAge(3600)
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/controller/ClimbingAreaController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/ClimbingAreaController.kt
@@ -2,6 +2,7 @@ package com.example.climbingapi.controller
 
 import com.example.climbingapi.dto.ClimbingAreaResponse
 import com.example.climbingapi.dto.CreateClimbingAreaRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateClimbingAreaRequest
 import com.example.climbingapi.dto.WallResponse
 import com.example.climbingapi.exception.ErrorResponse
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
@@ -38,8 +40,13 @@ class ClimbingAreaController(
 
     @Operation(summary = "List all climbing areas")
     @GetMapping
-    fun getAll(): List<ClimbingAreaResponse> =
-        climbingAreaService.getAll().map { climbingAreaMapper.toResponse(it) }
+    fun getAll(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): PagedResponse<ClimbingAreaResponse> {
+        val paged = climbingAreaService.getAll(page, size)
+        return PagedResponse(paged.data.map { climbingAreaMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
+    }
 
     @Operation(summary = "Get a climbing area by ID")
     @ApiResponse(responseCode = "404", description = "Climbing area not found",

--- a/src/main/kotlin/com/example/climbingapi/controller/RouteController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/RouteController.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.controller
 
 import com.example.climbingapi.dto.CreateRouteRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.RouteResponse
 import com.example.climbingapi.dto.UpdateRouteRequest
 import com.example.climbingapi.exception.ErrorResponse
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
@@ -35,7 +37,13 @@ class RouteController(
 
     @Operation(summary = "List all routes")
     @GetMapping
-    fun getAll(): List<RouteResponse> = routeService.getAll().map { routeMapper.toResponse(it) }
+    fun getAll(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): PagedResponse<RouteResponse> {
+        val paged = routeService.getAll(page, size)
+        return PagedResponse(paged.data.map { routeMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
+    }
 
     @Operation(summary = "Get a route by ID")
     @ApiResponse(responseCode = "404", description = "Route not found",

--- a/src/main/kotlin/com/example/climbingapi/controller/UserController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/UserController.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.controller
 
 import com.example.climbingapi.dto.CreateUserRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.TickResponse
 import com.example.climbingapi.dto.UpdateUserRequest
 import com.example.climbingapi.dto.UserResponse
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
@@ -40,7 +42,13 @@ class UserController(
 
     @Operation(summary = "List all users")
     @GetMapping
-    fun getAll(): List<UserResponse> = userService.getAll().map { userMapper.toResponse(it) }
+    fun getAll(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): PagedResponse<UserResponse> {
+        val paged = userService.getAll(page, size)
+        return PagedResponse(paged.data.map { userMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
+    }
 
     @Operation(summary = "Get a user by ID")
     @ApiResponse(responseCode = "404", description = "User not found",
@@ -81,6 +89,12 @@ class UserController(
     @ApiResponse(responseCode = "404", description = "User not found",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))])
     @GetMapping("/{userId}/ticks")
-    fun getTicks(@PathVariable userId: Int): List<TickResponse> =
-        tickService.getByUserId(userId).map { tickMapper.toResponse(it) }
+    fun getTicks(
+        @PathVariable userId: Int,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): PagedResponse<TickResponse> {
+        val paged = tickService.getByUserId(userId, page, size)
+        return PagedResponse(paged.data.map { tickMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
+    }
 }

--- a/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.controller
 
 import com.example.climbingapi.dto.CreateWallRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.RouteResponse
 import com.example.climbingapi.dto.UpdateWallRequest
 import com.example.climbingapi.dto.WallResponse
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
@@ -38,7 +40,13 @@ class WallController(
 
     @Operation(summary = "List all walls")
     @GetMapping
-    fun getAll(): List<WallResponse> = wallService.getAll().map { wallMapper.toResponse(it) }
+    fun getAll(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): PagedResponse<WallResponse> {
+        val paged = wallService.getAll(page, size)
+        return PagedResponse(paged.data.map { wallMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
+    }
 
     @Operation(summary = "Get a wall by ID")
     @ApiResponse(responseCode = "404", description = "Wall not found",

--- a/src/main/kotlin/com/example/climbingapi/dto/PagedResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/PagedResponse.kt
@@ -1,0 +1,8 @@
+package com.example.climbingapi.dto
+
+data class PagedResponse<T>(
+    val data: List<T>,
+    val page: Int,
+    val pageSize: Int,
+    val total: Int
+)

--- a/src/main/kotlin/com/example/climbingapi/repository/ClimbingAreaRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/ClimbingAreaRepository.kt
@@ -25,7 +25,7 @@ class ClimbingAreaRepository (
         )
     }
 
-    fun getAll(): List<ClimbingArea> {
+    fun getAll(page: Int, size: Int): List<ClimbingArea> {
         val sql = """
             SELECT id,
                    name,
@@ -35,8 +35,14 @@ class ClimbingAreaRepository (
                    region,
                    created_at
             FROM climbing_areas
+            ORDER BY id
+            LIMIT ? OFFSET ?
         """.trimIndent()
-        return jdbcTemplate.query(sql, climbingAreaMapper)
+        return jdbcTemplate.query(sql, climbingAreaMapper, size, page * size)
+    }
+
+    fun count(): Int {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM climbing_areas", Int::class.java) ?: 0
     }
 
     fun getById(id: Int): ClimbingArea? {

--- a/src/main/kotlin/com/example/climbingapi/repository/RouteRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/RouteRepository.kt
@@ -29,7 +29,7 @@ class RouteRepository(
         )
     }
 
-    fun getAll(): List<Route> {
+    fun getAll(page: Int, size: Int): List<Route> {
         val sql = """
             SELECT id,
                    wall_id,
@@ -43,8 +43,14 @@ class RouteRepository(
                    first_ascendant,
                    description
             FROM routes
+            ORDER BY id
+            LIMIT ? OFFSET ?
         """.trimIndent()
-        return jdbcTemplate.query(sql, routeRowMapper)
+        return jdbcTemplate.query(sql, routeRowMapper, size, page * size)
+    }
+
+    fun count(): Int {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM routes", Int::class.java) ?: 0
     }
 
     fun getById(id: Int): Route? {

--- a/src/main/kotlin/com/example/climbingapi/repository/TickRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/TickRepository.kt
@@ -32,14 +32,22 @@ class TickRepository(
         return jdbcTemplate.query(sql, tickRowMapper, id).firstOrNull()
     }
 
-    fun findByUserId(userId: Int): List<UserRoute> {
+    fun findByUserId(userId: Int, page: Int, size: Int): List<UserRoute> {
         val sql = """
             SELECT id, user_id, route_id, ticked_at, style, rating, personal_note
             FROM user_route_ticks
             WHERE user_id = ?
             ORDER BY ticked_at DESC
+            LIMIT ? OFFSET ?
         """.trimIndent()
-        return jdbcTemplate.query(sql, tickRowMapper, userId)
+        return jdbcTemplate.query(sql, tickRowMapper, userId, size, page * size)
+    }
+
+    fun countByUserId(userId: Int): Int {
+        return jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM user_route_ticks WHERE user_id = ?",
+            Int::class.java, userId
+        ) ?: 0
     }
 
     fun create(tick: UserRoute): UserRoute {

--- a/src/main/kotlin/com/example/climbingapi/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/UserRepository.kt
@@ -20,12 +20,18 @@ class UserRepository(
         )
     }
 
-    fun getAll(): List<User> {
+    fun getAll(page: Int, size: Int): List<User> {
         val sql = """
             SELECT id, email, display_name, created_at
             FROM users
+            ORDER BY id
+            LIMIT ? OFFSET ?
         """.trimIndent()
-        return jdbcTemplate.query(sql, userRowMapper)
+        return jdbcTemplate.query(sql, userRowMapper, size, page * size)
+    }
+
+    fun count(): Int {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM users", Int::class.java) ?: 0
     }
 
     fun getById(id: Int): User? {

--- a/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
@@ -27,7 +27,7 @@ class WallRepository(
         )
     }
 
-    fun getAll(): List<Wall> {
+    fun getAll(page: Int, size: Int): List<Wall> {
         val sql = """
             SELECT
                 id,
@@ -39,8 +39,14 @@ class WallRepository(
                 approach_info,
                 created_at
             FROM walls
+            ORDER BY id
+            LIMIT ? OFFSET ?
         """.trimIndent()
-        return jdbcTemplate.query(sql, wallRowMapper)
+        return jdbcTemplate.query(sql, wallRowMapper, size, page * size)
+    }
+
+    fun count(): Int {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM walls", Int::class.java) ?: 0
     }
 
     fun getById(id: Int): Wall? {

--- a/src/main/kotlin/com/example/climbingapi/service/ClimbingAreaService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/ClimbingAreaService.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.service
 
 import com.example.climbingapi.dto.CreateClimbingAreaRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateClimbingAreaRequest
 import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.ClimbingArea
@@ -14,8 +15,11 @@ class ClimbingAreaService(
     private val wallService: WallService
 ) {
 
-    fun getAll(): List<ClimbingArea> {
-        return climbingAreaRepository.getAll()
+    fun getAll(page: Int, size: Int): PagedResponse<ClimbingArea> {
+        val effectiveSize = size.coerceIn(1, 100)
+        val data = climbingAreaRepository.getAll(page, effectiveSize)
+        val total = climbingAreaRepository.count()
+        return PagedResponse(data, page, effectiveSize, total)
     }
 
     fun getById(id: Int): ClimbingArea {

--- a/src/main/kotlin/com/example/climbingapi/service/RouteService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/RouteService.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.service
 
 import com.example.climbingapi.dto.CreateRouteRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateRouteRequest
 import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.Route
@@ -15,8 +16,11 @@ class RouteService(
     private val wallRepository: WallRepository
 ) {
 
-    fun getAll(): List<Route> {
-        return routeRepository.getAll()
+    fun getAll(page: Int, size: Int): PagedResponse<Route> {
+        val effectiveSize = size.coerceIn(1, 100)
+        val data = routeRepository.getAll(page, effectiveSize)
+        val total = routeRepository.count()
+        return PagedResponse(data, page, effectiveSize, total)
     }
 
     fun getById(id: Int): Route {

--- a/src/main/kotlin/com/example/climbingapi/service/TickService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/TickService.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.service
 
 import com.example.climbingapi.dto.CreateTickRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateTickRequest
 import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.UserRoute
@@ -17,9 +18,12 @@ class TickService(
     private val routeRepository: RouteRepository
 ) {
 
-    fun getByUserId(userId: Int): List<UserRoute> {
+    fun getByUserId(userId: Int, page: Int, size: Int): PagedResponse<UserRoute> {
         userRepository.getById(userId) ?: throw NotFoundException("User not found: $userId")
-        return tickRepository.findByUserId(userId)
+        val effectiveSize = size.coerceIn(1, 100)
+        val data = tickRepository.findByUserId(userId, page, effectiveSize)
+        val total = tickRepository.countByUserId(userId)
+        return PagedResponse(data, page, effectiveSize, total)
     }
 
     fun getById(userId: Int, tickId: Int): UserRoute {

--- a/src/main/kotlin/com/example/climbingapi/service/UserService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.service
 
 import com.example.climbingapi.dto.CreateUserRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateUserRequest
 import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.User
@@ -12,7 +13,12 @@ class UserService(
     private val userRepository: UserRepository
 ) {
 
-    fun getAll(): List<User> = userRepository.getAll()
+    fun getAll(page: Int, size: Int): PagedResponse<User> {
+        val effectiveSize = size.coerceIn(1, 100)
+        val data = userRepository.getAll(page, effectiveSize)
+        val total = userRepository.count()
+        return PagedResponse(data, page, effectiveSize, total)
+    }
 
     fun getById(id: Int): User {
         return userRepository.getById(id) ?: throw NotFoundException("User not found: $id")

--- a/src/main/kotlin/com/example/climbingapi/service/WallService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/WallService.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.service
 
 import com.example.climbingapi.dto.CreateWallRequest
+import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateWallRequest
 import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.Wall
@@ -14,8 +15,11 @@ class WallService(
     private val routeService: RouteService
 ) {
 
-    fun getAll(): List<Wall> {
-        return wallRepository.getAll()
+    fun getAll(page: Int, size: Int): PagedResponse<Wall> {
+        val effectiveSize = size.coerceIn(1, 100)
+        val data = wallRepository.getAll(page, effectiveSize)
+        val total = wallRepository.count()
+        return PagedResponse(data, page, effectiveSize, total)
     }
 
     fun getById(id: Int): Wall {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,18 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   flyway:
     enabled: true
+
+logging:
+  level:
+    root: INFO
+    com.example.climbingapi: DEBUG
+    org.springframework.jdbc.core: DEBUG

--- a/src/test/kotlin/com/example/climbingapi/ClimbingAreaServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/ClimbingAreaServiceTest.kt
@@ -1,0 +1,111 @@
+package com.example.climbingapi
+
+import com.example.climbingapi.dto.CreateClimbingAreaRequest
+import com.example.climbingapi.dto.UpdateClimbingAreaRequest
+import com.example.climbingapi.exception.NotFoundException
+import com.example.climbingapi.model.ClimbingArea
+import com.example.climbingapi.model.Wall
+import com.example.climbingapi.repository.ClimbingAreaRepository
+import com.example.climbingapi.service.ClimbingAreaService
+import com.example.climbingapi.service.WallService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.OffsetDateTime
+
+@ExtendWith(MockitoExtension::class)
+class ClimbingAreaServiceTest {
+
+    @Mock lateinit var climbingAreaRepository: ClimbingAreaRepository
+    @Mock lateinit var wallService: WallService
+
+    @InjectMocks
+    lateinit var climbingAreaService: ClimbingAreaService
+
+    private val sampleArea = ClimbingArea(1, "Test Crag", "A nice crag", null, null, "Oslo", OffsetDateTime.now())
+    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, OffsetDateTime.now())
+
+    @Test
+    fun `getById returns area when found`() {
+        `when`(climbingAreaRepository.getById(1)).thenReturn(sampleArea)
+        assertEquals(sampleArea, climbingAreaService.getById(1))
+    }
+
+    @Test
+    fun `getById throws NotFoundException when not found`() {
+        `when`(climbingAreaRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { climbingAreaService.getById(99) }
+    }
+
+    @Test
+    fun `getWalls validates area exists then delegates to wallService`() {
+        `when`(climbingAreaRepository.getById(1)).thenReturn(sampleArea)
+        `when`(wallService.getByAreaId(1)).thenReturn(listOf(sampleWall))
+        assertEquals(listOf(sampleWall), climbingAreaService.getWalls(1))
+    }
+
+    @Test
+    fun `getWalls throws NotFoundException when area missing`() {
+        `when`(climbingAreaRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { climbingAreaService.getWalls(99) }
+    }
+
+    @Test
+    fun `create trims name and returns area`() {
+        val request = CreateClimbingAreaRequest(name = "  Test Crag  ", description = "A nice crag",
+            latitude = null, longitude = null, region = "Oslo")
+        val expected = sampleArea
+        `when`(climbingAreaRepository.create(ClimbingArea(null, "Test Crag", "A nice crag", null, null, "Oslo", null)))
+            .thenReturn(expected)
+        assertEquals(expected, climbingAreaService.create(request))
+    }
+
+    @Test
+    fun `update returns updated area`() {
+        val request = UpdateClimbingAreaRequest(name = "Updated Crag", description = null,
+            latitude = null, longitude = null, region = "Bergen")
+        val updated = sampleArea.copy(name = "Updated Crag", region = "Bergen")
+        `when`(climbingAreaRepository.update(1, ClimbingArea(null, "Updated Crag", null, null, null, "Bergen", null)))
+            .thenReturn(updated)
+        assertEquals(updated, climbingAreaService.update(1, request))
+    }
+
+    @Test
+    fun `update throws NotFoundException when area not found`() {
+        val request = UpdateClimbingAreaRequest(name = "X", description = null,
+            latitude = null, longitude = null, region = null)
+        `when`(climbingAreaRepository.update(99, ClimbingArea(null, "X", null, null, null, null, null)))
+            .thenReturn(null)
+        assertThrows(NotFoundException::class.java) { climbingAreaService.update(99, request) }
+    }
+
+    @Test
+    fun `delete throws NotFoundException when area not found`() {
+        `when`(climbingAreaRepository.deleteById(99)).thenReturn(false)
+        assertThrows(NotFoundException::class.java) { climbingAreaService.delete(99) }
+    }
+
+    @Test
+    fun `getAll returns paged response`() {
+        `when`(climbingAreaRepository.getAll(0, 20)).thenReturn(listOf(sampleArea))
+        `when`(climbingAreaRepository.count()).thenReturn(1)
+        val result = climbingAreaService.getAll(0, 20)
+        assertEquals(listOf(sampleArea), result.data)
+        assertEquals(0, result.page)
+        assertEquals(20, result.pageSize)
+        assertEquals(1, result.total)
+    }
+
+    @Test
+    fun `getAll clamps size to max 100`() {
+        `when`(climbingAreaRepository.getAll(0, 100)).thenReturn(emptyList())
+        `when`(climbingAreaRepository.count()).thenReturn(0)
+        val result = climbingAreaService.getAll(0, 150)
+        assertEquals(100, result.pageSize)
+    }
+}

--- a/src/test/kotlin/com/example/climbingapi/RouteServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/RouteServiceTest.kt
@@ -1,0 +1,113 @@
+package com.example.climbingapi
+
+import com.example.climbingapi.dto.CreateRouteRequest
+import com.example.climbingapi.dto.UpdateRouteRequest
+import com.example.climbingapi.exception.NotFoundException
+import com.example.climbingapi.model.Route
+import com.example.climbingapi.model.Wall
+import com.example.climbingapi.repository.RouteRepository
+import com.example.climbingapi.repository.WallRepository
+import com.example.climbingapi.service.RouteService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.OffsetDateTime
+
+@ExtendWith(MockitoExtension::class)
+class RouteServiceTest {
+
+    @Mock lateinit var routeRepository: RouteRepository
+    @Mock lateinit var wallRepository: WallRepository
+
+    @InjectMocks
+    lateinit var routeService: RouteService
+
+    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, OffsetDateTime.now())
+    private val sampleRoute = Route(1, 1, "Test Route", "6a", 20, "sport", 8, null, null, null, OffsetDateTime.now())
+
+    @Test
+    fun `getById returns route when found`() {
+        `when`(routeRepository.getById(1)).thenReturn(sampleRoute)
+        assertEquals(sampleRoute, routeService.getById(1))
+    }
+
+    @Test
+    fun `getById throws NotFoundException when not found`() {
+        `when`(routeRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { routeService.getById(99) }
+    }
+
+    @Test
+    fun `getByWallId delegates to repository`() {
+        `when`(routeRepository.findByWallId(1)).thenReturn(listOf(sampleRoute))
+        assertEquals(listOf(sampleRoute), routeService.getByWallId(1))
+    }
+
+    @Test
+    fun `create validates wall exists and returns route`() {
+        val request = CreateRouteRequest(wallId = 1, name = "New Route", grade = "6b", length = 15,
+            style = "sport", bolts = 6, ropeLengths = null, firstAscendant = null, description = null)
+        val expected = sampleRoute.copy(name = "New Route", grade = "6b")
+        `when`(wallRepository.getById(1)).thenReturn(sampleWall)
+        `when`(routeRepository.create(Route(null, 1, "New Route", "6b", 15, "sport", 6, null, null, null, null)))
+            .thenReturn(expected)
+
+        assertEquals(expected, routeService.create(request))
+    }
+
+    @Test
+    fun `create throws NotFoundException when wall missing`() {
+        val request = CreateRouteRequest(wallId = 99, name = "Route", grade = "6a", length = 10,
+            style = "sport", bolts = 5, ropeLengths = null, firstAscendant = null, description = null)
+        `when`(wallRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { routeService.create(request) }
+    }
+
+    @Test
+    fun `update throws NotFoundException when wall missing`() {
+        val request = UpdateRouteRequest(wallId = 99, name = "Route", grade = "6a", length = 10,
+            style = "sport", bolts = 5, ropeLengths = null, firstAscendant = null, description = null)
+        `when`(wallRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { routeService.update(1, request) }
+    }
+
+    @Test
+    fun `update throws NotFoundException when route missing`() {
+        val request = UpdateRouteRequest(wallId = 1, name = "Route", grade = "6a", length = 10,
+            style = "sport", bolts = 5, ropeLengths = null, firstAscendant = null, description = null)
+        `when`(wallRepository.getById(1)).thenReturn(sampleWall)
+        `when`(routeRepository.update(99, Route(null, 1, "Route", "6a", 10, "sport", 5, null, null, null, null)))
+            .thenReturn(null)
+        assertThrows(NotFoundException::class.java) { routeService.update(99, request) }
+    }
+
+    @Test
+    fun `delete throws NotFoundException when route not found`() {
+        `when`(routeRepository.deleteById(99)).thenReturn(false)
+        assertThrows(NotFoundException::class.java) { routeService.delete(99) }
+    }
+
+    @Test
+    fun `getAll returns paged response`() {
+        `when`(routeRepository.getAll(0, 20)).thenReturn(listOf(sampleRoute))
+        `when`(routeRepository.count()).thenReturn(1)
+        val result = routeService.getAll(0, 20)
+        assertEquals(listOf(sampleRoute), result.data)
+        assertEquals(0, result.page)
+        assertEquals(20, result.pageSize)
+        assertEquals(1, result.total)
+    }
+
+    @Test
+    fun `getAll clamps size to max 100`() {
+        `when`(routeRepository.getAll(0, 100)).thenReturn(emptyList())
+        `when`(routeRepository.count()).thenReturn(0)
+        val result = routeService.getAll(0, 200)
+        assertEquals(100, result.pageSize)
+    }
+}

--- a/src/test/kotlin/com/example/climbingapi/TickServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/TickServiceTest.kt
@@ -37,17 +37,18 @@ class TickServiceTest {
     @Test
     fun `getByUserId returns ticks when user exists`() {
         `when`(userRepository.getById(1)).thenReturn(sampleUser)
-        `when`(tickRepository.findByUserId(1)).thenReturn(listOf(sampleTick))
+        `when`(tickRepository.findByUserId(1, 0, 20)).thenReturn(listOf(sampleTick))
+        `when`(tickRepository.countByUserId(1)).thenReturn(1)
 
-        val result = tickService.getByUserId(1)
+        val result = tickService.getByUserId(1, 0, 20)
 
-        assertEquals(listOf(sampleTick), result)
+        assertEquals(listOf(sampleTick), result.data)
     }
 
     @Test
     fun `getByUserId throws NotFoundException when user missing`() {
         `when`(userRepository.getById(99)).thenReturn(null)
-        assertThrows(NotFoundException::class.java) { tickService.getByUserId(99) }
+        assertThrows(NotFoundException::class.java) { tickService.getByUserId(99, 0, 20) }
     }
 
     @Test

--- a/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
@@ -1,0 +1,114 @@
+package com.example.climbingapi
+
+import com.example.climbingapi.dto.CreateWallRequest
+import com.example.climbingapi.dto.UpdateWallRequest
+import com.example.climbingapi.exception.NotFoundException
+import com.example.climbingapi.model.Route
+import com.example.climbingapi.model.Wall
+import com.example.climbingapi.repository.WallRepository
+import com.example.climbingapi.service.RouteService
+import com.example.climbingapi.service.WallService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.OffsetDateTime
+
+@ExtendWith(MockitoExtension::class)
+class WallServiceTest {
+
+    @Mock lateinit var wallRepository: WallRepository
+    @Mock lateinit var routeService: RouteService
+
+    @InjectMocks
+    lateinit var wallService: WallService
+
+    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, OffsetDateTime.now())
+    private val sampleRoute = Route(1, 1, "Test Route", "6a", 20, "sport", 8, null, null, null, OffsetDateTime.now())
+
+    @Test
+    fun `getById returns wall when found`() {
+        `when`(wallRepository.getById(1)).thenReturn(sampleWall)
+        assertEquals(sampleWall, wallService.getById(1))
+    }
+
+    @Test
+    fun `getById throws NotFoundException when not found`() {
+        `when`(wallRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { wallService.getById(99) }
+    }
+
+    @Test
+    fun `getByAreaId delegates to repository`() {
+        `when`(wallRepository.findByAreaId(1)).thenReturn(listOf(sampleWall))
+        assertEquals(listOf(sampleWall), wallService.getByAreaId(1))
+    }
+
+    @Test
+    fun `getRoutes validates wall exists then delegates to routeService`() {
+        `when`(wallRepository.getById(1)).thenReturn(sampleWall)
+        `when`(routeService.getByWallId(1)).thenReturn(listOf(sampleRoute))
+        assertEquals(listOf(sampleRoute), wallService.getRoutes(1))
+    }
+
+    @Test
+    fun `getRoutes throws NotFoundException when wall missing`() {
+        `when`(wallRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { wallService.getRoutes(99) }
+    }
+
+    @Test
+    fun `create returns created wall`() {
+        val request = CreateWallRequest(areaId = 1, name = "New Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        val expected = sampleWall.copy(name = "New Wall")
+        `when`(wallRepository.create(Wall(null, 1, "New Wall", null, null, null, null, null))).thenReturn(expected)
+        assertEquals(expected, wallService.create(request))
+    }
+
+    @Test
+    fun `update returns updated wall`() {
+        val request = UpdateWallRequest(areaId = 1, name = "Updated Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        val updated = sampleWall.copy(name = "Updated Wall")
+        `when`(wallRepository.update(1, Wall(null, 1, "Updated Wall", null, null, null, null, null))).thenReturn(updated)
+        assertEquals(updated, wallService.update(1, request))
+    }
+
+    @Test
+    fun `update throws NotFoundException when wall not found`() {
+        val request = UpdateWallRequest(areaId = 1, name = "X", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        `when`(wallRepository.update(99, Wall(null, 1, "X", null, null, null, null, null))).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { wallService.update(99, request) }
+    }
+
+    @Test
+    fun `delete throws NotFoundException when wall not found`() {
+        `when`(wallRepository.deleteById(99)).thenReturn(false)
+        assertThrows(NotFoundException::class.java) { wallService.delete(99) }
+    }
+
+    @Test
+    fun `getAll returns paged response`() {
+        `when`(wallRepository.getAll(0, 20)).thenReturn(listOf(sampleWall))
+        `when`(wallRepository.count()).thenReturn(1)
+        val result = wallService.getAll(0, 20)
+        assertEquals(listOf(sampleWall), result.data)
+        assertEquals(0, result.page)
+        assertEquals(20, result.pageSize)
+        assertEquals(1, result.total)
+    }
+
+    @Test
+    fun `getAll clamps size to max 100`() {
+        `when`(wallRepository.getAll(0, 100)).thenReturn(emptyList())
+        `when`(wallRepository.count()).thenReturn(0)
+        val result = wallService.getAll(0, 500)
+        assertEquals(100, result.pageSize)
+    }
+}


### PR DESCRIPTION
Closes #35

## Summary

- **Pagination** — new `PagedResponse<T>(data, page, pageSize, total)` DTO; all 5 list endpoints (`/api/climbing-areas`, `/api/walls`, `/api/routes`, `/api/users`, `/api/users/{id}/ticks`) now accept `?page=0&size=20` query params; size is clamped to max 100 in the service layer; all 5 repositories gain `count()` + paginated `getAll()` with `LIMIT`/`OFFSET`
- **Config** — HikariCP pool settings (`maximum-pool-size: 10`, `minimum-idle: 2`, timeouts) added to `application.yaml`; structured logging levels added; `CorsConfig` gains `allowedHeaders("*")` and `maxAge(3600)`
- **Tests** — `RouteServiceTest`, `WallServiceTest`, `ClimbingAreaServiceTest` added following the Mockito + `@ExtendWith(MockitoExtension::class)` pattern; `TickServiceTest` updated for the new paginated `getByUserId` signature; 46 unit tests pass

## Test plan

- [ ] `./gradlew test` — 46 unit tests pass (1 integration test fails without DB, as expected)
- [ ] `GET /api/climbing-areas?page=0&size=5` returns `{ data: [...], page: 0, pageSize: 5, total: N }`
- [ ] `GET /api/walls?size=200` clamps to `pageSize: 100`
- [ ] `GET /api/users/{id}/ticks?page=1&size=10` returns correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)