### PR TITLE
Add input validation, security headers, and CORS hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Copy `.env` values as environment variables before running. The app reads the fo
 | `AUTH0_ISSUER_URI` | Auth0 dashboard → Applications → APIs → your API → Settings (e.g. `https://YOUR_TENANT.auth0.com/`) |
 | `AUTH0_AUDIENCE` | Auth0 dashboard → Applications → APIs → your API → API Audience |
 | `ALLOW_ORIGINS` | Production frontend URL for CORS (optional; localhost:5173 and localhost:8000 are always allowed) |
+| `SPRING_PROFILES_ACTIVE` | Set to `prod` in production to suppress JDBC debug logging (`application-prod.yaml`) |
 
 ```bash
 export $(grep -v '^#' .env | xargs)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Swagger UI is available at `http://localhost:8080/swagger-ui.html`.
 | `AUTH0_ISSUER_URI` | Auth0 issuer URI — Auth0 dashboard → Applications → APIs → your API → Issuer (e.g. `https://YOUR_TENANT.auth0.com/`) |
 | `AUTH0_AUDIENCE` | Auth0 API audience — Auth0 dashboard → Applications → APIs → your API → API Audience |
 | `ALLOW_ORIGINS` | Optional: production frontend URL added to the CORS allowlist (localhost:5173 and localhost:8000 are always allowed) |
+| `SPRING_PROFILES_ACTIVE` | Set to `prod` in production to suppress JDBC debug logging |
 
 ## Authentication
 

--- a/src/main/kotlin/com/example/climbingapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/climbingapi/config/SecurityConfig.kt
@@ -30,6 +30,16 @@ class SecurityConfig(
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .cors { it.configurationSource(corsConfigurationSource()) }
+            .headers { headers ->
+                headers.frameOptions { it.deny() }
+                headers.contentTypeOptions { }
+                headers.httpStrictTransportSecurity { hsts ->
+                    hsts.includeSubDomains(true)
+                    hsts.maxAgeInSeconds(31536000)
+                }
+                headers.cacheControl { }
+                headers.xssProtection { it.disable() }
+            }
             .authorizeHttpRequests { it.anyRequest().authenticated() }
             .oauth2ResourceServer { it.jwt { jwt -> jwt.decoder(jwtDecoder()) } }
             .exceptionHandling { it.authenticationEntryPoint(BearerTokenAuthenticationEntryPoint()) }
@@ -58,7 +68,8 @@ class SecurityConfig(
             System.getenv("ALLOW_ORIGINS") ?: ""
         ).filter { it.isNotBlank() }
         config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        config.allowedHeaders = listOf("*")
+        config.allowedHeaders = listOf("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With")
+        config.exposedHeaders = listOf("Location")
         config.allowCredentials = true
         config.maxAge = 3600L
         val source = UrlBasedCorsConfigurationSource()

--- a/src/main/kotlin/com/example/climbingapi/controller/ClimbingAreaController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/ClimbingAreaController.kt
@@ -15,8 +15,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
 
 @Tag(name = "Climbing Areas", description = "Manage climbing areas")
+@Validated
 @RestController
 @RequestMapping("/api/climbing-areas")
 class ClimbingAreaController(
@@ -41,8 +45,8 @@ class ClimbingAreaController(
     @Operation(summary = "List all climbing areas")
     @GetMapping
     fun getAll(
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int
     ): PagedResponse<ClimbingAreaResponse> {
         val paged = climbingAreaService.getAll(page, size)
         return PagedResponse(paged.data.map { climbingAreaMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)

--- a/src/main/kotlin/com/example/climbingapi/controller/RouteController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/RouteController.kt
@@ -13,8 +13,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
 
 @Tag(name = "Routes", description = "Manage climbing routes")
+@Validated
 @RestController
 @RequestMapping("/api/routes")
 class RouteController(
@@ -38,8 +42,8 @@ class RouteController(
     @Operation(summary = "List all routes")
     @GetMapping
     fun getAll(
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int
     ): PagedResponse<RouteResponse> {
         val paged = routeService.getAll(page, size)
         return PagedResponse(paged.data.map { routeMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)

--- a/src/main/kotlin/com/example/climbingapi/controller/UserController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/UserController.kt
@@ -17,8 +17,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -33,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
 
 @Tag(name = "Users", description = "Manage user accounts")
+@Validated
 @RestController
 @RequestMapping("/api/users")
 class UserController(
@@ -45,8 +49,8 @@ class UserController(
     @Operation(summary = "List all users")
     @GetMapping
     fun getAll(
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int
     ): PagedResponse<UserResponse> {
         val paged = userService.getAll(page, size)
         return PagedResponse(paged.data.map { userMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
@@ -121,8 +125,8 @@ class UserController(
     @GetMapping("/{userId}/ticks")
     fun getTicks(
         @PathVariable userId: Int,
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
         jwt: JwtAuthenticationToken
     ): PagedResponse<TickResponse> {
         userService.assertOwner(userId, jwt.token.subject)

--- a/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
@@ -15,8 +15,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
 
 @Tag(name = "Walls", description = "Manage climbing walls")
+@Validated
 @RestController
 @RequestMapping("/api/walls")
 class WallController(
@@ -41,8 +45,8 @@ class WallController(
     @Operation(summary = "List all walls")
     @GetMapping
     fun getAll(
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int
     ): PagedResponse<WallResponse> {
         val paged = wallService.getAll(page, size)
         return PagedResponse(paged.data.map { wallMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateClimbingAreaRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateClimbingAreaRequest.kt
@@ -1,14 +1,29 @@
 package com.example.climbingapi.dto
 
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 import java.math.BigDecimal
 
 data class CreateClimbingAreaRequest(
     @field:NotBlank(message = "name is required.")
+    @field:Size(max = 200, message = "name must be at most 200 characters.")
     val name: String,
 
+    @field:Size(max = 2000, message = "description must be at most 2000 characters.")
     val description: String?,
+
+    @field:DecimalMin(value = "-90.0", message = "latitude must be between -90 and 90.")
+    @field:DecimalMax(value = "90.0", message = "latitude must be between -90 and 90.")
     val latitude: BigDecimal?,
+
+    @field:DecimalMin(value = "-180.0", message = "longitude must be between -180 and 180.")
+    @field:DecimalMax(value = "180.0", message = "longitude must be between -180 and 180.")
     val longitude: BigDecimal?,
+
+    @field:Size(max = 100, message = "region must be at most 100 characters.")
+    @field:Pattern(regexp = "^[\\p{L}\\s'\\-.,]*$", message = "region contains invalid characters.")
     val region: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateRouteRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateRouteRequest.kt
@@ -1,17 +1,25 @@
 package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class CreateRouteRequest(
     @field:Min(value = 1, message = "wallId must be at least 1.")
     val wallId: Int,
 
+    @field:Size(max = 200, message = "name must be at most 200 characters.")
     val name: String?,
+
+    @field:Size(max = 20, message = "grade must be at most 20 characters.")
+    @field:Pattern(regexp = "^[a-zA-Z0-9+\\-/. ]*$", message = "grade contains invalid characters.")
     val grade: String?,
 
     @field:Min(value = 1, message = "length must be at least 1.")
     val length: Int?,
 
+    @field:Size(max = 50, message = "style must be at most 50 characters.")
+    @field:Pattern(regexp = "^[\\w\\-]*$", message = "style may only contain alphanumeric characters and hyphens.")
     val style: String?,
 
     @field:Min(value = 0, message = "bolts must be 0 or greater.")
@@ -20,6 +28,10 @@ data class CreateRouteRequest(
     @field:Min(value = 1, message = "ropeLengths must be at least 1.")
     val ropeLengths: Int?,
 
+    @field:Size(max = 200, message = "firstAscendant must be at most 200 characters.")
+    @field:Pattern(regexp = "^[\\p{L}\\s'\\-.,]*$", message = "firstAscendant contains invalid characters.")
     val firstAscendant: String?,
+
+    @field:Size(max = 2000, message = "description must be at most 2000 characters.")
     val description: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateTickRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateTickRequest.kt
@@ -2,10 +2,24 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class CreateTickRequest(
     @field:Min(1) val routeId: Int,
+
+    @field:Pattern(
+        regexp = "^(onsight|flash|redpoint)$",
+        message = "style must be one of: onsight, flash, redpoint."
+    )
     val style: String?,
+
     @field:Min(1) @field:Max(5) val rating: Int?,
+
+    @field:Size(max = 500, message = "personalNote must be at most 500 characters.")
+    @field:Pattern(
+        regexp = "^[\\w\\s'.,!?()\\-]*$",
+        message = "personalNote contains invalid characters."
+    )
     val personalNote: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateUserRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateUserRequest.kt
@@ -2,8 +2,16 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class CreateUserRequest(
-    @field:NotBlank val displayName: String,
-    @field:Email @field:NotBlank val email: String
+    @field:NotBlank
+    @field:Size(max = 100, message = "displayName must be at most 100 characters.")
+    @field:Pattern(regexp = "^[\\p{L}\\p{N}\\s'\\-_.]*$", message = "displayName contains invalid characters.")
+    val displayName: String,
+
+    @field:Email @field:NotBlank
+    @field:Size(max = 255, message = "email must be at most 255 characters.")
+    val email: String
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/CreateWallRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/CreateWallRequest.kt
@@ -1,7 +1,10 @@
 package com.example.climbingapi.dto
 
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.math.BigDecimal
 
 data class CreateWallRequest(
@@ -9,10 +12,20 @@ data class CreateWallRequest(
     val areaId: Int,
 
     @field:NotBlank(message = "name is required.")
+    @field:Size(max = 200, message = "name must be at most 200 characters.")
     val name: String,
 
+    @field:Size(max = 2000, message = "description must be at most 2000 characters.")
     val description: String?,
+
+    @field:DecimalMin(value = "-90.0", message = "latitude must be between -90 and 90.")
+    @field:DecimalMax(value = "90.0", message = "latitude must be between -90 and 90.")
     val latitude: BigDecimal?,
+
+    @field:DecimalMin(value = "-180.0", message = "longitude must be between -180 and 180.")
+    @field:DecimalMax(value = "180.0", message = "longitude must be between -180 and 180.")
     val longitude: BigDecimal?,
+
+    @field:Size(max = 2000, message = "approachInfo must be at most 2000 characters.")
     val approachInfo: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateClimbingAreaRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateClimbingAreaRequest.kt
@@ -1,14 +1,29 @@
 package com.example.climbingapi.dto
 
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 import java.math.BigDecimal
 
 data class UpdateClimbingAreaRequest(
     @field:NotBlank(message = "name is required.")
+    @field:Size(max = 200, message = "name must be at most 200 characters.")
     val name: String,
 
+    @field:Size(max = 2000, message = "description must be at most 2000 characters.")
     val description: String?,
+
+    @field:DecimalMin(value = "-90.0", message = "latitude must be between -90 and 90.")
+    @field:DecimalMax(value = "90.0", message = "latitude must be between -90 and 90.")
     val latitude: BigDecimal?,
+
+    @field:DecimalMin(value = "-180.0", message = "longitude must be between -180 and 180.")
+    @field:DecimalMax(value = "180.0", message = "longitude must be between -180 and 180.")
     val longitude: BigDecimal?,
+
+    @field:Size(max = 100, message = "region must be at most 100 characters.")
+    @field:Pattern(regexp = "^[\\p{L}\\s'\\-.,]*$", message = "region contains invalid characters.")
     val region: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateRouteRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateRouteRequest.kt
@@ -1,17 +1,25 @@
 package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class UpdateRouteRequest(
     @field:Min(value = 1, message = "wallId must be at least 1.")
     val wallId: Int,
 
+    @field:Size(max = 200, message = "name must be at most 200 characters.")
     val name: String?,
+
+    @field:Size(max = 20, message = "grade must be at most 20 characters.")
+    @field:Pattern(regexp = "^[a-zA-Z0-9+\\-/. ]*$", message = "grade contains invalid characters.")
     val grade: String?,
 
     @field:Min(value = 1, message = "length must be at least 1.")
     val length: Int?,
 
+    @field:Size(max = 50, message = "style must be at most 50 characters.")
+    @field:Pattern(regexp = "^[\\w\\-]*$", message = "style may only contain alphanumeric characters and hyphens.")
     val style: String?,
 
     @field:Min(value = 0, message = "bolts must be 0 or greater.")
@@ -20,6 +28,10 @@ data class UpdateRouteRequest(
     @field:Min(value = 1, message = "ropeLengths must be at least 1.")
     val ropeLengths: Int?,
 
+    @field:Size(max = 200, message = "firstAscendant must be at most 200 characters.")
+    @field:Pattern(regexp = "^[\\p{L}\\s'\\-.,]*$", message = "firstAscendant contains invalid characters.")
     val firstAscendant: String?,
+
+    @field:Size(max = 2000, message = "description must be at most 2000 characters.")
     val description: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateTickRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateTickRequest.kt
@@ -2,9 +2,22 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class UpdateTickRequest(
+    @field:Pattern(
+        regexp = "^(onsight|flash|redpoint)$",
+        message = "style must be one of: onsight, flash, redpoint."
+    )
     val style: String?,
+
     @field:Min(1) @field:Max(5) val rating: Int?,
+
+    @field:Size(max = 500, message = "personalNote must be at most 500 characters.")
+    @field:Pattern(
+        regexp = "^[\\w\\s'.,!?()\\-]*$",
+        message = "personalNote contains invalid characters."
+    )
     val personalNote: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateUserRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateUserRequest.kt
@@ -2,8 +2,16 @@ package com.example.climbingapi.dto
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 data class UpdateUserRequest(
-    @field:NotBlank @field:Email val email: String,
-    @field:NotBlank val displayName: String
+    @field:NotBlank @field:Email
+    @field:Size(max = 255, message = "email must be at most 255 characters.")
+    val email: String,
+
+    @field:NotBlank
+    @field:Size(max = 100, message = "displayName must be at most 100 characters.")
+    @field:Pattern(regexp = "^[\\p{L}\\p{N}\\s'\\-_.]*$", message = "displayName contains invalid characters.")
+    val displayName: String
 )

--- a/src/main/kotlin/com/example/climbingapi/dto/UpdateWallRequest.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/UpdateWallRequest.kt
@@ -1,7 +1,10 @@
 package com.example.climbingapi.dto
 
+import jakarta.validation.constraints.DecimalMax
+import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.math.BigDecimal
 
 data class UpdateWallRequest(
@@ -9,10 +12,20 @@ data class UpdateWallRequest(
     val areaId: Int,
 
     @field:NotBlank(message = "name is required.")
+    @field:Size(max = 200, message = "name must be at most 200 characters.")
     val name: String,
 
+    @field:Size(max = 2000, message = "description must be at most 2000 characters.")
     val description: String?,
+
+    @field:DecimalMin(value = "-90.0", message = "latitude must be between -90 and 90.")
+    @field:DecimalMax(value = "90.0", message = "latitude must be between -90 and 90.")
     val latitude: BigDecimal?,
+
+    @field:DecimalMin(value = "-180.0", message = "longitude must be between -180 and 180.")
+    @field:DecimalMax(value = "180.0", message = "longitude must be between -180 and 180.")
     val longitude: BigDecimal?,
+
+    @field:Size(max = 2000, message = "approachInfo must be at most 2000 characters.")
     val approachInfo: String?
 )

--- a/src/main/kotlin/com/example/climbingapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/climbingapi/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.example.climbingapi.exception
 
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -34,6 +35,14 @@ class GlobalExceptionHandler {
     )
     fun handleBadRequest(exception: Exception, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         val message = extractBadRequestMessage(exception)
+        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request)
+    }
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolation(exception: ConstraintViolationException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
+        val message = exception.constraintViolations.joinToString("; ") { cv ->
+            "${cv.propertyPath}: ${cv.message}"
+        }
         return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request)
     }
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,5 @@
+logging:
+  level:
+    root: WARN
+    com.example.climbingapi: INFO
+    org.springframework.jdbc.core: WARN

--- a/src/test/kotlin/com/example/climbingapi/integration/RouteControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/RouteControllerIT.kt
@@ -132,4 +132,18 @@ class RouteControllerIT : IntegrationTestBase() {
         mockMvc.perform(delete("$baseUrl/999").with(testJwt()))
             .andExpect(status().isNotFound)
     }
+
+    @Test
+    fun `GET routes with negative page returns 400`() {
+        mockMvc.perform(get("$baseUrl?page=-1").with(testJwt()))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    @Test
+    fun `GET routes with size above 100 returns 400`() {
+        mockMvc.perform(get("$baseUrl?size=101").with(testJwt()))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
 }

--- a/src/test/kotlin/com/example/climbingapi/integration/TickControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/TickControllerIT.kt
@@ -178,4 +178,47 @@ class TickControllerIT : IntegrationTestBase() {
             .andExpect(jsonPath("$.total").value(1))
             .andExpect(jsonPath("$.data[0].routeId").value(routeId))
     }
+
+    @Test
+    fun `POST tick with invalid style returns 400`() {
+        mockMvc.perform(
+            post(ticksUrl()).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"routeId":$routeId,"style":"invalid-style"}""")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    @Test
+    fun `POST tick with script in personalNote returns 400`() {
+        mockMvc.perform(
+            post(ticksUrl()).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"routeId":$routeId,"personalNote":"<script>alert(1)</script>"}""")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    @Test
+    fun `POST tick with personalNote over 500 chars returns 400`() {
+        val longNote = "a".repeat(501)
+        mockMvc.perform(
+            post(ticksUrl()).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"routeId":$routeId,"personalNote":"$longNote"}""")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    @Test
+    fun `PUT tick with script in personalNote returns 400`() {
+        postJson(ticksUrl(), """{"routeId":$routeId}""")
+
+        mockMvc.perform(
+            put("${ticksUrl()}/1").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"personalNote":"<img src=x onerror=alert(1)>"}""")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
 }

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -156,4 +156,24 @@ class WallControllerIT : IntegrationTestBase() {
         mockMvc.perform(get("$baseUrl/999/routes").with(testJwt()))
             .andExpect(status().isNotFound)
     }
+
+    @Test
+    fun `POST wall with latitude above 90 returns 400`() {
+        mockMvc.perform(
+            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"areaId":$areaId,"name":"North Face","latitude":91.0}""")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    @Test
+    fun `POST wall with longitude below minus 180 returns 400`() {
+        mockMvc.perform(
+            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"areaId":$areaId,"name":"North Face","longitude":-181.0}""")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
 }


### PR DESCRIPTION
## Summary

- **Issue #40**: Tick `personalNote` limited to 500 chars with safe-character pattern; `style` restricted to `onsight`, `flash`, `redpoint`
- **All request DTOs**: `@Size` max limits on all string fields; `@Pattern` on structured fields (`grade`, `region`, `displayName`, `firstAscendant`); coordinate range validation (`lat ±90`, `lon ±180`) on walls and climbing areas
- **Pagination hardening**: `@Validated` + `@Min`/`@Max` on `page`/`size` params across all controllers; `ConstraintViolationException` handler added to `GlobalExceptionHandler`
- **HTTP security headers**: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, HSTS (1 year, includeSubDomains), `Cache-Control`
- **CORS**: `allowedHeaders` narrowed from wildcard `*` to explicit list; `Location` header exposed so frontend can read `201` redirect URLs cross-origin
- **Production logging**: `application-prod.yaml` suppresses JDBC debug output — activate with `SPRING_PROFILES_ACTIVE=prod`

## Test plan

- [x] All 49 service unit tests pass (`./gradlew test --tests "com.example.climbingapi.*ServiceTest"`)
- [x] Integration tests pass with Docker running (`./gradlew test`)
- [x] New tick tests: `POST` with `style: "invalid-style"` → 400; `personalNote: "<script>..."` → 400; note > 500 chars → 400
- [x] New pagination tests: `GET /api/routes?page=-1` → 400; `GET /api/routes?size=101` → 400
- [x] New coordinate tests: `POST /api/walls` with `latitude: 91` → 400; `longitude: -181` → 400

## Known gap (out of scope)

Routes, walls, and climbing areas have no ownership model — any authenticated user can mutate any record. This is likely intentional (community-editable data) but should be confirmed before production deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)