### PR TITLE
Require admin role for catalog writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ All five domain types have a complete Controller/Service/Repository stack.
 - All REST endpoints are prefixed with `/api`.
 - All `/api/**` endpoints require a valid Auth0 JWT (`Authorization: Bearer <token>`). Returns 401 if missing, 403 if the caller is not the resource owner.
 - Tick and user-write endpoints enforce ownership: the JWT `sub` claim must match `auth0_id` on the user record.
+- Catalog writes (POST/PUT/DELETE on `/api/climbing-areas`, `/api/walls`, `/api/routes`) require the `admin` role. Roles come from the `https://climbing-api/roles` JWT claim (set by an Auth0 post-login Action) and are mapped to `ROLE_admin` in `SecurityConfig.kt`. Reads of these resources, and own-resource tick/user writes, need only authentication. The role check runs in the security filter *before* controller validation, so a non-admin write returns 403 (never 400).
 - Multi-step service methods (e.g. validate → insert) are annotated `@Transactional`.
 - List endpoints return `PagedResponse<T>` with `data`, `page`, `pageSize`, `total` fields. Size is clamped to max 100 in the service layer.
 

--- a/src/main/kotlin/com/example/climbingapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/climbingapi/config/SecurityConfig.kt
@@ -1,21 +1,30 @@
 package com.example.climbingapi.config
 
+import com.example.climbingapi.exception.ErrorResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
 import org.springframework.security.oauth2.jwt.JwtClaimValidator
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtValidators
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import java.time.OffsetDateTime
 
 @Configuration
 @EnableWebSecurity
@@ -24,8 +33,10 @@ class SecurityConfig(
     @Value("\${auth0.audience}") private val audience: String
 ) {
 
+    private val rolesClaim = "https://climbing-api/roles"
+
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun securityFilterChain(http: HttpSecurity, accessDeniedHandler: AccessDeniedHandler): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
@@ -40,11 +51,50 @@ class SecurityConfig(
                 headers.cacheControl { }
                 headers.xssProtection { it.disable() }
             }
-            .authorizeHttpRequests { it.anyRequest().authenticated() }
-            .oauth2ResourceServer { it.jwt { jwt -> jwt.decoder(jwtDecoder()) } }
-            .exceptionHandling { it.authenticationEntryPoint(BearerTokenAuthenticationEntryPoint()) }
+            .authorizeHttpRequests {
+                it.requestMatchers(HttpMethod.POST, "/api/climbing-areas/**", "/api/walls/**", "/api/routes/**").hasRole("admin")
+                it.requestMatchers(HttpMethod.PUT, "/api/climbing-areas/**", "/api/walls/**", "/api/routes/**").hasRole("admin")
+                it.requestMatchers(HttpMethod.DELETE, "/api/climbing-areas/**", "/api/walls/**", "/api/routes/**").hasRole("admin")
+                it.anyRequest().authenticated()
+            }
+            .oauth2ResourceServer {
+                it.jwt { jwt ->
+                    jwt.decoder(jwtDecoder())
+                    jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())
+                }
+            }
+            .exceptionHandling {
+                it.authenticationEntryPoint(BearerTokenAuthenticationEntryPoint())
+                it.accessDeniedHandler(accessDeniedHandler)
+            }
         return http.build()
     }
+
+    @Bean
+    fun jwtAuthenticationConverter(): JwtAuthenticationConverter {
+        val converter = JwtAuthenticationConverter()
+        converter.setJwtGrantedAuthoritiesConverter { jwt ->
+            (jwt.getClaimAsStringList(rolesClaim) ?: emptyList())
+                .map { SimpleGrantedAuthority("ROLE_$it") }
+        }
+        return converter
+    }
+
+    @Bean
+    fun accessDeniedHandler(objectMapper: ObjectMapper): AccessDeniedHandler =
+        AccessDeniedHandler { request, response, _ ->
+            response.status = HttpStatus.FORBIDDEN.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            val body = ErrorResponse(
+                timestamp = OffsetDateTime.now(),
+                status = HttpStatus.FORBIDDEN.value(),
+                error = HttpStatus.FORBIDDEN.reasonPhrase,
+                errorCode = "FORBIDDEN",
+                message = "Admin role required",
+                path = request.requestURI
+            )
+            objectMapper.writeValue(response.outputStream, body)
+        }
 
     @Bean
     fun jwtDecoder(): JwtDecoder {

--- a/src/test/kotlin/com/example/climbingapi/integration/ClimbingAreaControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/ClimbingAreaControllerIT.kt
@@ -43,7 +43,7 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
 
     @Test
     fun `POST area returns 201 with Location header`() {
-        mockMvc.perform(post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON).content(validArea))
+        mockMvc.perform(post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content(validArea))
             .andExpect(status().isCreated)
             .andExpect(header().string("Location", org.hamcrest.Matchers.containsString("/api/climbing-areas/")))
             .andExpect(jsonPath("$.id").value(1))
@@ -51,8 +51,15 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
     }
 
     @Test
+    fun `POST area without admin role returns 403`() {
+        mockMvc.perform(post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON).content(validArea))
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"))
+    }
+
+    @Test
     fun `POST area with blank name returns 400`() {
-        mockMvc.perform(post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON).content("""{"name":""}"""))
+        mockMvc.perform(post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content("""{"name":""}"""))
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
     }
@@ -78,7 +85,7 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
         postJson(baseUrl, validArea)
 
         mockMvc.perform(
-            put("$baseUrl/1").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/1").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"name":"Siurana","region":"Catalonia"}""")
         )
             .andExpect(status().isOk)
@@ -89,7 +96,7 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
     @Test
     fun `PUT area with unknown id returns 404`() {
         mockMvc.perform(
-            put("$baseUrl/999").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/999").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"name":"Siurana"}""")
         )
             .andExpect(status().isNotFound)
@@ -100,7 +107,7 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
         postJson(baseUrl, validArea)
 
         mockMvc.perform(
-            put("$baseUrl/1").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/1").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"name":""}""")
         )
             .andExpect(status().isBadRequest)
@@ -111,13 +118,13 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
     fun `DELETE area returns 204`() {
         postJson(baseUrl, validArea)
 
-        mockMvc.perform(delete("$baseUrl/1").with(testJwt()))
+        mockMvc.perform(delete("$baseUrl/1").with(adminJwt()))
             .andExpect(status().isNoContent)
     }
 
     @Test
     fun `DELETE area with unknown id returns 404`() {
-        mockMvc.perform(delete("$baseUrl/999").with(testJwt()))
+        mockMvc.perform(delete("$baseUrl/999").with(adminJwt()))
             .andExpect(status().isNotFound)
     }
 
@@ -126,7 +133,7 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
         postJson(baseUrl, validArea)
         postJson("/api/walls", """{"areaId":1,"name":"Main Wall"}""")
 
-        mockMvc.perform(delete("$baseUrl/1").with(testJwt())).andExpect(status().isNoContent)
+        mockMvc.perform(delete("$baseUrl/1").with(adminJwt())).andExpect(status().isNoContent)
 
         mockMvc.perform(get("/api/walls/1").with(testJwt()))
             .andExpect(status().isNotFound)

--- a/src/test/kotlin/com/example/climbingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/IntegrationTestBase.kt
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -55,7 +56,16 @@ abstract class IntegrationTestBase {
         builder.claim("email", email)
     }
 
-    protected fun postJson(url: String, body: String, jwtPp: RequestPostProcessor = testJwt()): String =
+    protected fun adminJwt(
+        sub: String = "google-oauth2|test-user-123",
+        email: String = "test@example.com"
+    ): RequestPostProcessor = jwt().jwt { builder ->
+        builder.subject(sub)
+        builder.claim("email", email)
+        builder.claim("https://climbing-api/roles", listOf("admin"))
+    }.authorities(SimpleGrantedAuthority("ROLE_admin"))
+
+    protected fun postJson(url: String, body: String, jwtPp: RequestPostProcessor = adminJwt()): String =
         mockMvc.perform(
             post(url).with(jwtPp).contentType(MediaType.APPLICATION_JSON).content(body)
         )

--- a/src/test/kotlin/com/example/climbingapi/integration/RouteControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/RouteControllerIT.kt
@@ -31,7 +31,7 @@ class RouteControllerIT : IntegrationTestBase() {
     @Test
     fun `POST route returns 201 with Location header`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"wallId":$wallId,"name":"Slab Route","grade":"6a"}""")
         )
             .andExpect(status().isCreated)
@@ -41,9 +41,19 @@ class RouteControllerIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `POST route with wallId zero returns 400`() {
+    fun `POST route without admin role returns 403`() {
         mockMvc.perform(
             post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"wallId":$wallId,"name":"Slab Route"}""")
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"))
+    }
+
+    @Test
+    fun `POST route with wallId zero returns 400`() {
+        mockMvc.perform(
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"wallId":0}""")
         )
             .andExpect(status().isBadRequest)
@@ -53,7 +63,7 @@ class RouteControllerIT : IntegrationTestBase() {
     @Test
     fun `POST route with non-existent wallId returns 404`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"wallId":9999,"name":"Ghost Route"}""")
         )
             .andExpect(status().isNotFound)
@@ -91,7 +101,7 @@ class RouteControllerIT : IntegrationTestBase() {
         postJson(baseUrl, """{"wallId":$wallId,"name":"Slab Route","grade":"6a"}""")
 
         mockMvc.perform(
-            put("$baseUrl/1").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/1").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"wallId":$wallId,"name":"Overhang","grade":"7b"}""")
         )
             .andExpect(status().isOk)
@@ -102,7 +112,7 @@ class RouteControllerIT : IntegrationTestBase() {
     @Test
     fun `PUT route with unknown id returns 404`() {
         mockMvc.perform(
-            put("$baseUrl/999").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/999").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"wallId":$wallId,"name":"Overhang"}""")
         )
             .andExpect(status().isNotFound)
@@ -113,7 +123,7 @@ class RouteControllerIT : IntegrationTestBase() {
         postJson(baseUrl, """{"wallId":$wallId,"name":"Slab Route"}""")
 
         mockMvc.perform(
-            put("$baseUrl/1").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/1").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"wallId":9999,"name":"Overhang"}""")
         )
             .andExpect(status().isNotFound)
@@ -123,13 +133,13 @@ class RouteControllerIT : IntegrationTestBase() {
     fun `DELETE route returns 204`() {
         postJson(baseUrl, """{"wallId":$wallId,"name":"Slab Route"}""")
 
-        mockMvc.perform(delete("$baseUrl/1").with(testJwt()))
+        mockMvc.perform(delete("$baseUrl/1").with(adminJwt()))
             .andExpect(status().isNoContent)
     }
 
     @Test
     fun `DELETE route with unknown id returns 404`() {
-        mockMvc.perform(delete("$baseUrl/999").with(testJwt()))
+        mockMvc.perform(delete("$baseUrl/999").with(adminJwt()))
             .andExpect(status().isNotFound)
     }
 

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -30,7 +30,7 @@ class WallControllerIT : IntegrationTestBase() {
     @Test
     fun `POST wall returns 201 with Location header`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":$areaId,"name":"North Face"}""")
         )
             .andExpect(status().isCreated)
@@ -40,9 +40,19 @@ class WallControllerIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `POST wall with areaId zero returns 400`() {
+    fun `POST wall without admin role returns 403`() {
         mockMvc.perform(
             post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+                .content("""{"areaId":$areaId,"name":"North Face"}""")
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"))
+    }
+
+    @Test
+    fun `POST wall with areaId zero returns 400`() {
+        mockMvc.perform(
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":0,"name":"North Face"}""")
         )
             .andExpect(status().isBadRequest)
@@ -52,7 +62,7 @@ class WallControllerIT : IntegrationTestBase() {
     @Test
     fun `POST wall with non-existent areaId returns 409 from FK violation`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":9999,"name":"Ghost Wall"}""")
         )
             .andExpect(status().isConflict)
@@ -61,7 +71,7 @@ class WallControllerIT : IntegrationTestBase() {
     @Test
     fun `POST wall with blank name returns 400`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":$areaId,"name":""}""")
         )
             .andExpect(status().isBadRequest)
@@ -99,7 +109,7 @@ class WallControllerIT : IntegrationTestBase() {
         postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
 
         mockMvc.perform(
-            put("$baseUrl/1").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/1").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":$areaId,"name":"South Slab"}""")
         )
             .andExpect(status().isOk)
@@ -109,7 +119,7 @@ class WallControllerIT : IntegrationTestBase() {
     @Test
     fun `PUT wall with unknown id returns 404`() {
         mockMvc.perform(
-            put("$baseUrl/999").with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            put("$baseUrl/999").with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":$areaId,"name":"South Slab"}""")
         )
             .andExpect(status().isNotFound)
@@ -119,13 +129,13 @@ class WallControllerIT : IntegrationTestBase() {
     fun `DELETE wall returns 204`() {
         postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
 
-        mockMvc.perform(delete("$baseUrl/1").with(testJwt()))
+        mockMvc.perform(delete("$baseUrl/1").with(adminJwt()))
             .andExpect(status().isNoContent)
     }
 
     @Test
     fun `DELETE wall with unknown id returns 404`() {
-        mockMvc.perform(delete("$baseUrl/999").with(testJwt()))
+        mockMvc.perform(delete("$baseUrl/999").with(adminJwt()))
             .andExpect(status().isNotFound)
     }
 
@@ -134,7 +144,7 @@ class WallControllerIT : IntegrationTestBase() {
         postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
         postJson("/api/routes", """{"wallId":1,"name":"Test Route"}""")
 
-        mockMvc.perform(delete("$baseUrl/1").with(testJwt())).andExpect(status().isNoContent)
+        mockMvc.perform(delete("$baseUrl/1").with(adminJwt())).andExpect(status().isNoContent)
 
         mockMvc.perform(get("/api/routes/1").with(testJwt()))
             .andExpect(status().isNotFound)
@@ -160,7 +170,7 @@ class WallControllerIT : IntegrationTestBase() {
     @Test
     fun `POST wall with latitude above 90 returns 400`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":$areaId,"name":"North Face","latitude":91.0}""")
         )
             .andExpect(status().isBadRequest)
@@ -170,7 +180,7 @@ class WallControllerIT : IntegrationTestBase() {
     @Test
     fun `POST wall with longitude below minus 180 returns 400`() {
         mockMvc.perform(
-            post(baseUrl).with(testJwt()).contentType(MediaType.APPLICATION_JSON)
+            post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON)
                 .content("""{"areaId":$areaId,"name":"North Face","longitude":-181.0}""")
         )
             .andExpect(status().isBadRequest)


### PR DESCRIPTION
## Context

An `admin` role was added in the Auth0 dashboard, and a post-login Action now emits the caller's roles as a `https://climbing-api/roles` claim. The backend previously ignored this claim entirely — Spring's default converter only reads `scope`/`scp` — so **any authenticated user could create/edit/delete the shared catalog** (climbing-areas, walls, routes).

This change makes the role meaningful: catalog **writes** are now admin-only; reads and own-resource tick/user writes are unchanged.

## Changes

**`SecurityConfig.kt`**
- `JwtAuthenticationConverter` maps the `https://climbing-api/roles` claim to `ROLE_admin` authorities.
- `POST`/`PUT`/`DELETE` on `/api/climbing-areas/**`, `/api/walls/**`, `/api/routes/**` require `hasRole("admin")`; everything else stays `authenticated()`. Ticks (`/api/users/**`) are untouched.
- Custom `AccessDeniedHandler` returns the role-denied 403 in the same `{ timestamp, status, error, errorCode, message, path }` shape as the existing ownership 403.

**Tests**
- New `adminJwt()` helper in `IntegrationTestBase` (grants `ROLE_admin` directly — the mock `jwt()` postprocessor bypasses the real decoder/converter). `postJson` now defaults to it.
- Catalog write calls switched to `adminJwt()`; GETs stay non-admin (proving reads remain open).
- Added a `... without admin role returns 403` test per catalog controller.

**`CLAUDE.md`** — documented the admin gate and the filter-before-validation ordering (a non-admin write returns 403, never 400).

## Notes

- The role check runs in the security filter **before** controller validation, so a non-admin write returns 403 rather than 400.
- Integration tests mock the JWT and assign the authority directly, so they exercise the authorization rules but not the claim→authority conversion. The converter logic is small; a manual check with a real admin/non-admin token covers the end-to-end path.

## Verification

`./gradlew test` — all green (including the three new 403 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)