### PR TITLE
Add wall image upload to Cloudflare R2 (admin only) (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ Copy `.env` values as environment variables before running. The app reads the fo
 | `AUTH0_AUDIENCE` | Auth0 dashboard → Applications → APIs → your API → API Audience |
 | `ALLOW_ORIGINS` | Production frontend URL for CORS (optional; localhost:5173 and localhost:8000 are always allowed) |
 | `SPRING_PROFILES_ACTIVE` | Set to `prod` in production to suppress JDBC debug logging (`application-prod.yaml`) |
+| `R2_ENDPOINT` | Cloudflare R2 S3 API endpoint (`https://<ACCOUNT_ID>.r2.cloudflarestorage.com`) |
+| `R2_ACCESS_KEY_ID` | R2 API token access key (Cloudflare dashboard → R2 → Manage API Tokens) |
+| `R2_SECRET_ACCESS_KEY` | R2 API token secret |
+| `R2_BUCKET` | R2 bucket name for wall images |
 
 ```bash
 export $(grep -v '^#' .env | xargs)
@@ -93,9 +97,10 @@ Kotlin + Spring Boot 3.5 REST API backed by **PostgreSQL 16**. Uses **Spring Dat
 | GET | `/api/climbing-areas` | List all areas; supports `?page=0&size=20` (max 100) |
 | GET | `/api/walls` | List all walls; supports `?page=0&size=20` (max 100) |
 | GET | `/api/walls/{id}` | 404 if not found |
-| POST | `/api/walls` | Returns 201; `areaId` required |
+| POST | `/api/walls` | Returns 201; `areaId` required. Accepts `application/json`, or `multipart/form-data` with a JSON part `wall` + optional `image` file (admin only) |
 | GET | `/api/walls/{wallId}/routes` | 404 if wall not found |
-| PUT | `/api/walls/{id}` | Full replace; 404 if not found |
+| PUT | `/api/walls/{id}` | Full replace; 404 if not found. Does not touch `image_key` |
+| PUT | `/api/walls/{id}/image` | Admin only; `multipart/form-data` with an `image` file; uploads to R2, replaces old image; 404 if wall not found |
 | GET | `/api/routes` | List all routes; supports `?page=0&size=20` (max 100) |
 | GET | `/api/routes/{id}` | 404 if not found |
 | POST | `/api/routes` | Returns 201; validates wall exists |
@@ -148,6 +153,17 @@ Flyway migrations live in `src/main/resources/db/migration/`. New migrations mus
 | `V1__create_tables.sql` | Full schema (all 5 tables) |
 | `V2__schema_improvements.sql` | NOT NULL on FK cols, UNIQUE on email + ticks, CASCADE deletes, FK indexes, lat/lng precision |
 | `V3__add_auth0_id.sql` | Add nullable `auth0_id VARCHAR(128)` + unique constraint + index to `users` table |
+| `V4__widen_description_columns.sql` | Widen `walls.description` and `walls.approach_info` to `TEXT` |
+| `V5__add_wall_image_key.sql` | Add nullable `image_key VARCHAR(512)` to `walls` (R2 object key for the wall image) |
+
+## Wall images
+
+Wall photos are stored in **Cloudflare R2** (S3-compatible), not in Postgres. The wall row holds only
+the R2 **object key** (`walls.image_key`); read responses expose a short-lived **presigned GET URL** as
+`WallResponse.imageUrl` (built in `WallMapper` via `StorageService.presignGet`). Uploads (multipart `POST
+/api/walls` and `PUT /api/walls/{id}/image`) are admin-only, accept JPEG/PNG/WebP up to 5 MB, and replace
+the previous object best-effort. `StorageService` is the storage port; `R2StorageService` is the AWS SDK v2
+implementation, wired in `config/StorageConfig.kt` from `config/R2Properties.kt` (`storage.r2.*`).
 
 ## Related projects
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,14 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom 'software.amazon.awssdk:bom:2.46.17'
+    }
+}
+
 dependencies {
+    implementation 'software.amazon.awssdk:s3'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/kotlin/com/example/climbingapi/config/R2Properties.kt
+++ b/src/main/kotlin/com/example/climbingapi/config/R2Properties.kt
@@ -1,0 +1,12 @@
+package com.example.climbingapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "storage.r2")
+data class R2Properties(
+    val endpoint: String,
+    val accessKeyId: String,
+    val secretAccessKey: String,
+    val bucket: String,
+    val presignDurationMinutes: Long = 15
+)

--- a/src/main/kotlin/com/example/climbingapi/config/StorageConfig.kt
+++ b/src/main/kotlin/com/example/climbingapi/config/StorageConfig.kt
@@ -1,0 +1,42 @@
+package com.example.climbingapi.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import java.net.URI
+
+@Configuration
+@EnableConfigurationProperties(R2Properties::class)
+class StorageConfig(private val props: R2Properties) {
+
+    // R2 is S3-compatible: override the endpoint, use region "auto", and path-style access.
+    private fun credentials() =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create(props.accessKeyId, props.secretAccessKey))
+
+    private val serviceConfiguration: S3Configuration =
+        S3Configuration.builder().pathStyleAccessEnabled(true).build()
+
+    @Bean
+    fun s3Client(): S3Client =
+        S3Client.builder()
+            .endpointOverride(URI.create(props.endpoint))
+            .region(Region.of("auto"))
+            .credentialsProvider(credentials())
+            .serviceConfiguration(serviceConfiguration)
+            .build()
+
+    @Bean
+    fun s3Presigner(): S3Presigner =
+        S3Presigner.builder()
+            .endpointOverride(URI.create(props.endpoint))
+            .region(Region.of("auto"))
+            .credentialsProvider(credentials())
+            .serviceConfiguration(serviceConfiguration)
+            .build()
+}

--- a/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
@@ -18,6 +18,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -28,8 +29,10 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.util.UriComponentsBuilder
 
 @Tag(name = "Walls", description = "Manage climbing walls")
@@ -68,12 +71,32 @@ class WallController(
     @Operation(summary = "Create a wall")
     @ApiResponse(responseCode = "400", description = "Validation error",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))])
-    @PostMapping
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
     fun create(@Valid @RequestBody request: CreateWallRequest, ucb: UriComponentsBuilder): ResponseEntity<WallResponse> {
-        val created = wallMapper.toResponse(wallService.create(request))
-        val location = ucb.path("/api/walls/{id}").buildAndExpand(created.id).toUri()
-        return ResponseEntity.created(location).body(created)
+        return created(wallService.create(request), ucb)
     }
+
+    @Operation(summary = "Create a wall with an optional image (admin only)",
+        description = "multipart/form-data: a JSON part named 'wall' plus an optional 'image' file part.")
+    @ApiResponse(responseCode = "400", description = "Validation error",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))])
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun createMultipart(
+        @Valid @RequestPart("wall") request: CreateWallRequest,
+        @RequestPart(value = "image", required = false) image: MultipartFile?,
+        ucb: UriComponentsBuilder
+    ): ResponseEntity<WallResponse> {
+        return created(wallService.create(request, image), ucb)
+    }
+
+    @Operation(summary = "Upload or replace a wall's image (admin only)")
+    @ApiResponse(responseCode = "404", description = "Wall not found",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))])
+    @ApiResponse(responseCode = "400", description = "Validation error",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))])
+    @PutMapping("/{id}/image", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun replaceImage(@PathVariable id: Int, @RequestPart("image") image: MultipartFile): WallResponse =
+        wallMapper.toResponse(wallService.replaceImage(id, image))
 
     @Operation(summary = "Update a wall")
     @ApiResponse(responseCode = "404", description = "Wall not found",
@@ -91,4 +114,10 @@ class WallController(
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun delete(@PathVariable id: Int) = wallService.delete(id)
+
+    private fun created(wall: com.example.climbingapi.model.Wall, ucb: UriComponentsBuilder): ResponseEntity<WallResponse> {
+        val response = wallMapper.toResponse(wall)
+        val location = ucb.path("/api/walls/{id}").buildAndExpand(response.id).toUri()
+        return ResponseEntity.created(location).body(response)
+    }
 }

--- a/src/main/kotlin/com/example/climbingapi/dto/WallResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/WallResponse.kt
@@ -11,5 +11,6 @@ data class WallResponse(
     val latitude: BigDecimal?,
     val longitude: BigDecimal?,
     val approachInfo: String?,
+    val imageUrl: String?,
     val createdAt: OffsetDateTime
 )

--- a/src/main/kotlin/com/example/climbingapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/climbingapi/exception/GlobalExceptionHandler.kt
@@ -12,6 +12,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.multipart.MaxUploadSizeExceededException
+import software.amazon.awssdk.core.exception.SdkException
 import java.time.OffsetDateTime
 
 @RestControllerAdvice
@@ -49,6 +51,18 @@ class GlobalExceptionHandler {
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     fun handleMethodNotAllowed(exception: HttpRequestMethodNotSupportedException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
         return buildResponse(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", exception.message ?: "Method not allowed", request)
+    }
+
+    @ExceptionHandler(PayloadTooLargeException::class, MaxUploadSizeExceededException::class)
+    fun handlePayloadTooLarge(exception: Exception, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
+        val message = if (exception is PayloadTooLargeException) exception.message ?: "Payload too large"
+        else "Uploaded file exceeds the maximum allowed size."
+        return buildResponse(HttpStatus.PAYLOAD_TOO_LARGE, "PAYLOAD_TOO_LARGE", message, request)
+    }
+
+    @ExceptionHandler(SdkException::class)
+    fun handleStorageError(exception: SdkException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
+        return buildResponse(HttpStatus.BAD_GATEWAY, "STORAGE_ERROR", "Image storage is unavailable.", request)
     }
 
     @ExceptionHandler(DataIntegrityViolationException::class)

--- a/src/main/kotlin/com/example/climbingapi/exception/PayloadTooLargeException.kt
+++ b/src/main/kotlin/com/example/climbingapi/exception/PayloadTooLargeException.kt
@@ -1,0 +1,3 @@
+package com.example.climbingapi.exception
+
+class PayloadTooLargeException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/example/climbingapi/mapper/WallMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/WallMapper.kt
@@ -2,10 +2,13 @@ package com.example.climbingapi.mapper
 
 import com.example.climbingapi.dto.WallResponse
 import com.example.climbingapi.model.Wall
+import com.example.climbingapi.service.StorageService
 import org.springframework.stereotype.Component
 
 @Component
-class WallMapper {
+class WallMapper(
+    private val storageService: StorageService
+) {
 
     fun toResponse(wall: Wall): WallResponse {
         return WallResponse(
@@ -16,6 +19,7 @@ class WallMapper {
             latitude = wall.latitude,
             longitude = wall.longitude,
             approachInfo = wall.approachInfo,
+            imageUrl = wall.imageKey?.let { storageService.presignGet(it) },
             createdAt = wall.createdAt!!
         )
     }

--- a/src/main/kotlin/com/example/climbingapi/model/Wall.kt
+++ b/src/main/kotlin/com/example/climbingapi/model/Wall.kt
@@ -11,5 +11,6 @@ data class Wall(
     val latitude: BigDecimal?,
     val longitude: BigDecimal?,
     val approachInfo: String?,
+    val imageKey: String?,
     val createdAt: OffsetDateTime?
 )

--- a/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
@@ -4,7 +4,6 @@ import com.example.climbingapi.model.Wall
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
-import java.math.BigDecimal
 import java.time.OffsetDateTime
 
 @Repository
@@ -23,6 +22,7 @@ class WallRepository(
             latitude = rs.getBigDecimal("latitude"),
             longitude = rs.getBigDecimal("longitude"),
             approachInfo = rs.getString("approach_info"),
+            imageKey = rs.getString("image_key"),
             createdAt = createdTime
         )
     }
@@ -37,6 +37,7 @@ class WallRepository(
                 latitude,
                 longitude,
                 approach_info,
+                image_key,
                 created_at
             FROM walls
             ORDER BY id
@@ -59,6 +60,7 @@ class WallRepository(
                 latitude,
                 longitude,
                 approach_info,
+                image_key,
                 created_at
             FROM walls
             WHERE id = ?
@@ -71,6 +73,7 @@ class WallRepository(
     }
 
     fun update(id: Int, wall: Wall): Wall? {
+        // image_key is intentionally not touched here — images are managed via PUT /{id}/image.
         val sql = """
             UPDATE walls
             SET area_id = ?,
@@ -87,6 +90,7 @@ class WallRepository(
                       latitude,
                       longitude,
                       approach_info,
+                      image_key,
                       created_at
         """.trimIndent()
         return jdbcTemplate.query(
@@ -102,6 +106,24 @@ class WallRepository(
         ).firstOrNull()
     }
 
+    fun updateImageKey(id: Int, imageKey: String): Wall? {
+        val sql = """
+            UPDATE walls
+            SET image_key = ?
+            WHERE id = ?
+            RETURNING id,
+                      area_id,
+                      name,
+                      description,
+                      latitude,
+                      longitude,
+                      approach_info,
+                      image_key,
+                      created_at
+        """.trimIndent()
+        return jdbcTemplate.query(sql, wallRowMapper, imageKey, id).firstOrNull()
+    }
+
     fun findByAreaId(areaId: Int): List<Wall> {
         val sql = """
             SELECT
@@ -112,6 +134,7 @@ class WallRepository(
                 latitude,
                 longitude,
                 approach_info,
+                image_key,
                 created_at
             FROM walls
             WHERE area_id = ?
@@ -128,9 +151,10 @@ class WallRepository(
                 description,
                 latitude,
                 longitude,
-                approach_info
+                approach_info,
+                image_key
             )
-            VALUES (?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             RETURNING id,
                       area_id,
                       name,
@@ -138,6 +162,7 @@ class WallRepository(
                       latitude,
                       longitude,
                       approach_info,
+                      image_key,
                       created_at
         """.trimIndent()
 
@@ -149,7 +174,8 @@ class WallRepository(
             wall.description,
             wall.latitude,
             wall.longitude,
-            wall.approachInfo
+            wall.approachInfo,
+            wall.imageKey
         ).firstOrNull() ?: error("INSERT RETURNING returned no row")
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/service/R2StorageService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/R2StorageService.kt
@@ -1,0 +1,65 @@
+package com.example.climbingapi.service
+
+import com.example.climbingapi.config.R2Properties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.core.exception.SdkException
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import java.time.Duration
+import java.util.UUID
+
+@Service
+class R2StorageService(
+    private val s3Client: S3Client,
+    private val s3Presigner: S3Presigner,
+    private val props: R2Properties
+) : StorageService {
+
+    override fun upload(bytes: ByteArray, contentType: String): String {
+        val key = "walls/${UUID.randomUUID()}.${extensionFor(contentType)}"
+        s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(props.bucket)
+                .key(key)
+                .contentType(contentType)
+                .build(),
+            RequestBody.fromBytes(bytes)
+        )
+        return key
+    }
+
+    override fun delete(key: String) {
+        try {
+            s3Client.deleteObject(
+                DeleteObjectRequest.builder().bucket(props.bucket).key(key).build()
+            )
+        } catch (e: SdkException) {
+            logger.warn("Failed to delete R2 object {}: {}", key, e.message)
+        }
+    }
+
+    override fun presignGet(key: String): String {
+        val presignRequest = GetObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(props.presignDurationMinutes))
+            .getObjectRequest(GetObjectRequest.builder().bucket(props.bucket).key(key).build())
+            .build()
+        return s3Presigner.presignGetObject(presignRequest).url().toString()
+    }
+
+    private fun extensionFor(contentType: String): String = when (contentType) {
+        "image/jpeg" -> "jpg"
+        "image/png" -> "png"
+        "image/webp" -> "webp"
+        else -> throw IllegalArgumentException("Unsupported image type: $contentType")
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(R2StorageService::class.java)
+    }
+}

--- a/src/main/kotlin/com/example/climbingapi/service/StorageService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/StorageService.kt
@@ -1,0 +1,18 @@
+package com.example.climbingapi.service
+
+/**
+ * Object storage for wall images (Cloudflare R2 in production).
+ * Implementations persist raw bytes and return an opaque object key; the key is what
+ * is stored on the wall record. Reads turn the key back into a short-lived presigned URL.
+ */
+interface StorageService {
+
+    /** Uploads the given bytes and returns the generated object key. */
+    fun upload(bytes: ByteArray, contentType: String): String
+
+    /** Best-effort delete; failures are logged, not thrown. */
+    fun delete(key: String)
+
+    /** Returns a short-lived presigned GET URL for the object key. */
+    fun presignGet(key: String): String
+}

--- a/src/main/kotlin/com/example/climbingapi/service/WallService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/WallService.kt
@@ -4,15 +4,19 @@ import com.example.climbingapi.dto.CreateWallRequest
 import com.example.climbingapi.dto.PagedResponse
 import com.example.climbingapi.dto.UpdateWallRequest
 import com.example.climbingapi.exception.NotFoundException
+import com.example.climbingapi.exception.PayloadTooLargeException
 import com.example.climbingapi.model.Wall
 import com.example.climbingapi.model.Route
 import com.example.climbingapi.repository.WallRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 class WallService(
     private val wallRepository: WallRepository,
-    private val routeService: RouteService
+    private val routeService: RouteService,
+    private val storageService: StorageService
 ) {
 
     fun getAll(page: Int, size: Int): PagedResponse<Wall> {
@@ -49,11 +53,13 @@ class WallService(
             latitude = request.latitude,
             longitude = request.longitude,
             approachInfo = request.approachInfo,
+            imageKey = null,
             createdAt = null
         )) ?: throw NotFoundException("Wall not found: $id")
     }
 
-    fun create(request: CreateWallRequest): Wall {
+    fun create(request: CreateWallRequest, image: MultipartFile? = null): Wall {
+        val imageKey = image?.let { uploadImage(it) }
         val wall = Wall(
             id = null,
             areaId = request.areaId,
@@ -62,9 +68,47 @@ class WallService(
             latitude = request.latitude,
             longitude = request.longitude,
             approachInfo = request.approachInfo,
+            imageKey = imageKey,
             createdAt = null
         )
 
-        return wallRepository.create(wall)
+        return try {
+            wallRepository.create(wall)
+        } catch (e: Exception) {
+            // Compensate the orphaned object if the row insert fails (e.g. bad areaId FK).
+            imageKey?.let { storageService.delete(it) }
+            throw e
+        }
+    }
+
+    @Transactional
+    fun replaceImage(id: Int, image: MultipartFile): Wall {
+        val oldKey = getById(id).imageKey
+        val newKey = uploadImage(image)
+        val updated = try {
+            wallRepository.updateImageKey(id, newKey) ?: throw NotFoundException("Wall not found: $id")
+        } catch (e: Exception) {
+            storageService.delete(newKey)
+            throw e
+        }
+        oldKey?.let { storageService.delete(it) }
+        return updated
+    }
+
+    private fun uploadImage(image: MultipartFile): String {
+        if (image.isEmpty) throw IllegalArgumentException("Image file is empty.")
+        val contentType = image.contentType
+        if (contentType == null || contentType !in ALLOWED_IMAGE_TYPES) {
+            throw IllegalArgumentException("Unsupported image type. Allowed: image/jpeg, image/png, image/webp.")
+        }
+        if (image.size > MAX_IMAGE_BYTES) {
+            throw PayloadTooLargeException("Image exceeds the maximum size of 5 MB.")
+        }
+        return storageService.upload(image.bytes, contentType)
+    }
+
+    companion object {
+        private val ALLOWED_IMAGE_TYPES = setOf("image/jpeg", "image/png", "image/webp")
+        private const val MAX_IMAGE_BYTES = 5L * 1024 * 1024
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,11 @@ spring:
   flyway:
     enabled: true
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 6MB
+
   security:
     oauth2:
       resourceserver:
@@ -25,6 +30,14 @@ spring:
 
 auth0:
   audience: ${AUTH0_AUDIENCE}
+
+storage:
+  r2:
+    endpoint: ${R2_ENDPOINT}
+    access-key-id: ${R2_ACCESS_KEY_ID}
+    secret-access-key: ${R2_SECRET_ACCESS_KEY}
+    bucket: ${R2_BUCKET}
+    presign-duration-minutes: 15
 
 logging:
   level:

--- a/src/main/resources/db/migration/V5__add_wall_image_key.sql
+++ b/src/main/resources/db/migration/V5__add_wall_image_key.sql
@@ -1,0 +1,3 @@
+-- Wall images: store the Cloudflare R2 object key (not a public URL).
+-- Nullable — walls without an image are fully supported.
+ALTER TABLE walls ADD COLUMN image_key VARCHAR(512);

--- a/src/test/kotlin/com/example/climbingapi/ClimbingAreaServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/ClimbingAreaServiceTest.kt
@@ -28,7 +28,7 @@ class ClimbingAreaServiceTest {
     lateinit var climbingAreaService: ClimbingAreaService
 
     private val sampleArea = ClimbingArea(1, "Test Crag", "A nice crag", null, null, "Oslo", OffsetDateTime.now())
-    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, OffsetDateTime.now())
+    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, null, OffsetDateTime.now())
 
     @Test
     fun `getById returns area when found`() {

--- a/src/test/kotlin/com/example/climbingapi/RouteServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/RouteServiceTest.kt
@@ -27,7 +27,7 @@ class RouteServiceTest {
     @InjectMocks
     lateinit var routeService: RouteService
 
-    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, OffsetDateTime.now())
+    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, null, OffsetDateTime.now())
     private val sampleRoute = Route(1, 1, "Test Route", "6a", 20, "sport", 8, null, null, null, OffsetDateTime.now())
 
     @Test

--- a/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
@@ -3,10 +3,12 @@ package com.example.climbingapi
 import com.example.climbingapi.dto.CreateWallRequest
 import com.example.climbingapi.dto.UpdateWallRequest
 import com.example.climbingapi.exception.NotFoundException
+import com.example.climbingapi.exception.PayloadTooLargeException
 import com.example.climbingapi.model.Route
 import com.example.climbingapi.model.Wall
 import com.example.climbingapi.repository.WallRepository
 import com.example.climbingapi.service.RouteService
+import com.example.climbingapi.service.StorageService
 import com.example.climbingapi.service.WallService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -14,8 +16,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.mock.web.MockMultipartFile
 import java.time.OffsetDateTime
 
 @ExtendWith(MockitoExtension::class)
@@ -23,12 +27,14 @@ class WallServiceTest {
 
     @Mock lateinit var wallRepository: WallRepository
     @Mock lateinit var routeService: RouteService
+    @Mock lateinit var storageService: StorageService
 
     @InjectMocks
     lateinit var wallService: WallService
 
-    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, OffsetDateTime.now())
+    private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, null, OffsetDateTime.now())
     private val sampleRoute = Route(1, 1, "Test Route", "6a", 20, "sport", 8, null, null, null, OffsetDateTime.now())
+    private val jpeg = MockMultipartFile("image", "photo.jpg", "image/jpeg", byteArrayOf(1, 2, 3))
 
     @Test
     fun `getById returns wall when found`() {
@@ -66,8 +72,67 @@ class WallServiceTest {
         val request = CreateWallRequest(areaId = 1, name = "New Wall", description = null,
             latitude = null, longitude = null, approachInfo = null)
         val expected = sampleWall.copy(name = "New Wall")
-        `when`(wallRepository.create(Wall(null, 1, "New Wall", null, null, null, null, null))).thenReturn(expected)
+        `when`(wallRepository.create(Wall(null, 1, "New Wall", null, null, null, null, null, null))).thenReturn(expected)
         assertEquals(expected, wallService.create(request))
+    }
+
+    @Test
+    fun `create with image uploads to storage and persists key`() {
+        val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        val expected = sampleWall.copy(name = "Photo Wall", imageKey = "walls/abc.jpg")
+        `when`(storageService.upload(jpeg.bytes, "image/jpeg")).thenReturn("walls/abc.jpg")
+        `when`(wallRepository.create(Wall(null, 1, "Photo Wall", null, null, null, null, "walls/abc.jpg", null)))
+            .thenReturn(expected)
+
+        assertEquals(expected, wallService.create(request, jpeg))
+    }
+
+    @Test
+    fun `create with image deletes uploaded object when insert fails`() {
+        val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        `when`(storageService.upload(jpeg.bytes, "image/jpeg")).thenReturn("walls/abc.jpg")
+        `when`(wallRepository.create(Wall(null, 1, "Photo Wall", null, null, null, null, "walls/abc.jpg", null)))
+            .thenThrow(RuntimeException("insert failed"))
+
+        assertThrows(RuntimeException::class.java) { wallService.create(request, jpeg) }
+        verify(storageService).delete("walls/abc.jpg")
+    }
+
+    @Test
+    fun `create with unsupported image type throws IllegalArgumentException`() {
+        val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        val text = MockMultipartFile("image", "note.txt", "text/plain", byteArrayOf(1))
+        assertThrows(IllegalArgumentException::class.java) { wallService.create(request, text) }
+    }
+
+    @Test
+    fun `create with oversized image throws PayloadTooLargeException`() {
+        val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        val big = MockMultipartFile("image", "big.jpg", "image/jpeg", ByteArray(5 * 1024 * 1024 + 1))
+        assertThrows(PayloadTooLargeException::class.java) { wallService.create(request, big) }
+    }
+
+    @Test
+    fun `replaceImage uploads new key, updates wall, and deletes old object`() {
+        val png = MockMultipartFile("image", "photo.png", "image/png", byteArrayOf(4, 5, 6))
+        `when`(wallRepository.getById(1)).thenReturn(sampleWall.copy(imageKey = "old-key"))
+        `when`(storageService.upload(png.bytes, "image/png")).thenReturn("new-key")
+        `when`(wallRepository.updateImageKey(1, "new-key")).thenReturn(sampleWall.copy(imageKey = "new-key"))
+
+        val result = wallService.replaceImage(1, png)
+
+        assertEquals("new-key", result.imageKey)
+        verify(storageService).delete("old-key")
+    }
+
+    @Test
+    fun `replaceImage on missing wall throws NotFoundException`() {
+        `when`(wallRepository.getById(99)).thenReturn(null)
+        assertThrows(NotFoundException::class.java) { wallService.replaceImage(99, jpeg) }
     }
 
     @Test
@@ -75,7 +140,7 @@ class WallServiceTest {
         val request = UpdateWallRequest(areaId = 1, name = "Updated Wall", description = null,
             latitude = null, longitude = null, approachInfo = null)
         val updated = sampleWall.copy(name = "Updated Wall")
-        `when`(wallRepository.update(1, Wall(null, 1, "Updated Wall", null, null, null, null, null))).thenReturn(updated)
+        `when`(wallRepository.update(1, Wall(null, 1, "Updated Wall", null, null, null, null, null, null))).thenReturn(updated)
         assertEquals(updated, wallService.update(1, request))
     }
 
@@ -83,7 +148,7 @@ class WallServiceTest {
     fun `update throws NotFoundException when wall not found`() {
         val request = UpdateWallRequest(areaId = 1, name = "X", description = null,
             latitude = null, longitude = null, approachInfo = null)
-        `when`(wallRepository.update(99, Wall(null, 1, "X", null, null, null, null, null))).thenReturn(null)
+        `when`(wallRepository.update(99, Wall(null, 1, "X", null, null, null, null, null, null))).thenReturn(null)
         assertThrows(NotFoundException::class.java) { wallService.update(99, request) }
     }
 

--- a/src/test/kotlin/com/example/climbingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/IntegrationTestBase.kt
@@ -34,6 +34,11 @@ abstract class IntegrationTestBase {
             registry.add("spring.datasource.password", postgres::getPassword)
             registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://test.auth0.local/" }
             registry.add("auth0.audience") { "test-audience" }
+            // Dummy R2 config so the S3 beans build; WallControllerIT swaps in a fake StorageService.
+            registry.add("storage.r2.endpoint") { "http://localhost:9999" }
+            registry.add("storage.r2.access-key-id") { "test" }
+            registry.add("storage.r2.secret-access-key") { "test" }
+            registry.add("storage.r2.bucket") { "test-bucket" }
         }
     }
 

--- a/src/test/kotlin/com/example/climbingapi/integration/R2StorageSmokeIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/R2StorageSmokeIT.kt
@@ -1,0 +1,101 @@
+package com.example.climbingapi.integration
+
+import com.example.climbingapi.config.R2Properties
+import com.example.climbingapi.service.R2StorageService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * Live round-trip against a real Cloudflare R2 bucket — the one thing the mocked ITs cannot cover.
+ * Skipped unless R2_ENDPOINT is set, so it never runs in CI or a normal `./gradlew build`.
+ *
+ * Run it manually with real credentials exported in your shell:
+ *   export R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+ *   export R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... R2_BUCKET=climbing-wall-images
+ *   ./gradlew test --tests "com.example.climbingapi.integration.R2StorageSmokeIT"
+ */
+@EnabledIfEnvironmentVariable(named = "R2_ENDPOINT", matches = ".+")
+class R2StorageSmokeIT {
+
+    private val props = R2Properties(
+        endpoint = env("R2_ENDPOINT"),
+        accessKeyId = env("R2_ACCESS_KEY_ID"),
+        secretAccessKey = env("R2_SECRET_ACCESS_KEY"),
+        bucket = env("R2_BUCKET"),
+        presignDurationMinutes = 5
+    )
+
+    private val credentials =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create(props.accessKeyId, props.secretAccessKey))
+    private val serviceConfig = S3Configuration.builder().pathStyleAccessEnabled(true).build()
+
+    private val s3 = S3Client.builder()
+        .endpointOverride(URI.create(props.endpoint))
+        .region(Region.of("auto"))
+        .credentialsProvider(credentials)
+        .serviceConfiguration(serviceConfig)
+        .build()
+
+    private val presigner = S3Presigner.builder()
+        .endpointOverride(URI.create(props.endpoint))
+        .region(Region.of("auto"))
+        .credentialsProvider(credentials)
+        .serviceConfiguration(serviceConfig)
+        .build()
+
+    private val storage = R2StorageService(s3, presigner, props)
+
+    @Test
+    fun `upload, presign-GET, then delete round-trips against R2`() {
+        // 1x1 transparent PNG
+        val png = byteArrayOf(
+            0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4.toByte(),
+            0x89.toByte(), 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+            0x54, 0x78, 0x9C.toByte(), 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4.toByte(), 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE.toByte(),
+            0x42, 0x60, 0x82.toByte()
+        )
+
+        val key = storage.upload(png, "image/png")
+        println("Uploaded R2 object key: $key")
+        assertTrue(key.startsWith("walls/") && key.endsWith(".png"), "unexpected key: $key")
+
+        val url = storage.presignGet(key)
+        // Don't log the full URL — it embeds the access key id and signature.
+        println("Presigned GET host/path: ${URI.create(url).let { "${it.scheme}://${it.host}${it.path}" }}")
+        val response = HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder(URI.create(url)).GET().build(),
+            HttpResponse.BodyHandlers.ofByteArray()
+        )
+
+        assertEquals(200, response.statusCode(), "presigned GET should return 200")
+        assertEquals(png.size, response.body().size, "downloaded bytes should match uploaded image")
+
+        storage.delete(key)
+        val afterDelete = HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder(URI.create(url)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        )
+        assertTrue(afterDelete.statusCode() in setOf(403, 404), "object should be gone after delete, was ${afterDelete.statusCode()}")
+        println("R2 round-trip OK: upload -> presign GET (200) -> delete -> gone (${afterDelete.statusCode()})")
+    }
+
+    private fun env(name: String): String =
+        System.getenv(name) ?: error("$name must be set to run R2StorageSmokeIT")
+}

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -1,17 +1,49 @@
 package com.example.climbingapi.integration
 
+import com.example.climbingapi.service.StorageService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
+import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
 
+@Import(WallControllerIT.FakeStorageConfig::class)
 class WallControllerIT : IntegrationTestBase() {
+
+    /** In-memory fake so the IT exercises the controller + DB without hitting R2. */
+    @TestConfiguration
+    class FakeStorageConfig {
+        @Bean
+        @Primary
+        fun fakeStorageService(): StorageService = object : StorageService {
+            override fun upload(bytes: ByteArray, contentType: String): String {
+                val ext = when (contentType) {
+                    "image/jpeg" -> "jpg"
+                    "image/png" -> "png"
+                    "image/webp" -> "webp"
+                    else -> throw IllegalArgumentException("Unsupported image type: $contentType")
+                }
+                return "walls/${UUID.randomUUID()}.$ext"
+            }
+
+            override fun delete(key: String) { /* no-op */ }
+
+            override fun presignGet(key: String): String = "https://fake-r2.local/$key?signed=true"
+        }
+    }
 
     private val baseUrl = "/api/walls"
     private var areaId = 0
@@ -185,5 +217,93 @@ class WallControllerIT : IntegrationTestBase() {
         )
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    private fun wallPart(name: String = "Photo Wall") =
+        MockMultipartFile("wall", "", MediaType.APPLICATION_JSON_VALUE, """{"areaId":$areaId,"name":"$name"}""".toByteArray())
+
+    private fun imagePart(filename: String = "photo.jpg", type: String = "image/jpeg", bytes: ByteArray = byteArrayOf(1, 2, 3)) =
+        MockMultipartFile("image", filename, type, bytes)
+
+    @Test
+    fun `POST wall multipart with image returns 201 with imageUrl`() {
+        mockMvc.perform(
+            multipart(baseUrl).file(wallPart()).file(imagePart()).with(adminJwt())
+        )
+            .andExpect(status().isCreated)
+            .andExpect(header().string("Location", org.hamcrest.Matchers.containsString("/api/walls/")))
+            .andExpect(jsonPath("$.name").value("Photo Wall"))
+            .andExpect(jsonPath("$.imageUrl").isNotEmpty)
+    }
+
+    @Test
+    fun `POST wall multipart without image returns 201 with null imageUrl`() {
+        mockMvc.perform(
+            multipart(baseUrl).file(wallPart("No Photo")).with(adminJwt())
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.name").value("No Photo"))
+            .andExpect(jsonPath("$.imageUrl").doesNotExist())
+    }
+
+    @Test
+    fun `POST wall multipart without admin role returns 403`() {
+        mockMvc.perform(
+            multipart(baseUrl).file(wallPart()).file(imagePart()).with(testJwt())
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"))
+    }
+
+    @Test
+    fun `PUT wall image returns 200 with imageUrl`() {
+        postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
+
+        mockMvc.perform(
+            multipart(HttpMethod.PUT, "$baseUrl/1/image").file(imagePart("photo.png", "image/png")).with(adminJwt())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.imageUrl").isNotEmpty)
+    }
+
+    @Test
+    fun `PUT wall image with unsupported type returns 400`() {
+        postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
+
+        mockMvc.perform(
+            multipart(HttpMethod.PUT, "$baseUrl/1/image").file(imagePart("note.txt", "text/plain")).with(adminJwt())
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+    }
+
+    @Test
+    fun `PUT wall image exceeding 5MB returns 413`() {
+        postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
+
+        mockMvc.perform(
+            multipart(HttpMethod.PUT, "$baseUrl/1/image")
+                .file(imagePart("big.jpg", "image/jpeg", ByteArray(5 * 1024 * 1024 + 1))).with(adminJwt())
+        )
+            .andExpect(status().isPayloadTooLarge)
+            .andExpect(jsonPath("$.errorCode").value("PAYLOAD_TOO_LARGE"))
+    }
+
+    @Test
+    fun `PUT wall image on unknown wall returns 404`() {
+        mockMvc.perform(
+            multipart(HttpMethod.PUT, "$baseUrl/999/image").file(imagePart()).with(adminJwt())
+        )
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PUT wall image without admin role returns 403`() {
+        postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
+
+        mockMvc.perform(
+            multipart(HttpMethod.PUT, "$baseUrl/1/image").file(imagePart()).with(testJwt())
+        )
+            .andExpect(status().isForbidden)
     }
 }


### PR DESCRIPTION
Closes #44.

Walls can now carry an image stored in **Cloudflare R2** (S3-compatible). Only the R2 **object key** is persisted (`walls.image_key`); reads expose a short-lived **presigned GET URL** as `WallResponse.imageUrl`.

## What changed
- **`POST /api/walls`** accepts `multipart/form-data` (a JSON part `wall` + optional `image` file) in addition to `application/json` — creating a wall without an image is unchanged.
- **`PUT /api/walls/{id}/image`** uploads or replaces a wall's image, deleting the previous R2 object best-effort.
- Both are **admin-only** via the existing `/api/walls/**` POST/PUT security matchers — no `SecurityConfig` change needed.
- Validates **JPEG/PNG/WebP up to 5 MB** → `400` (bad type) / `413` (oversize).
- `StorageService` port + `R2StorageService` (AWS SDK v2), wired from `R2Properties` (`storage.r2.*`).
- `GlobalExceptionHandler` maps `PayloadTooLargeException`/`MaxUploadSizeExceededException` → 413 and `SdkException` → 502 (`STORAGE_ERROR`).
- Flyway **V5** adds nullable `walls.image_key`.

## Design notes
- **Key + presign-on-read** (bucket stays private) rather than storing a public URL. Hence the column is `image_key`, not `image_url` as the issue phrased it.
- The full `PUT /api/walls/{id}` deliberately does **not** touch `image_key` (images are managed only via the image endpoints).

## Config / deployment (Hetzner)
R2 is external — set `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` as env vars on the host (same convention as `AUTH0_*`). No new infra.

## Tests
- `WallServiceTest` — upload, compensating delete on insert failure, type/size validation, replace-image.
- `WallControllerIT` — 8 multipart cases (201 with `imageUrl`, multipart-without-image, PUT image 200, 400 bad type, 413 oversize, 404, non-admin 403 on both paths) using an in-memory fake `StorageService` (no network). Flyway V5 is exercised by the Testcontainers Postgres.
- `./gradlew clean build` green.

⚠️ **Not yet verified against a live R2 bucket** (no credentials in the dev env) — the actual PutObject/presign round-trip should be smoke-tested once `R2_*` is set in deployment.

## Frontend coordination
API contract change tracked in climbing-web#33 (multipart `wall` part + `image` part; `imageUrl` is presigned/short-lived).

🤖 Generated with [Claude Code](https://claude.com/claude-code)