### PR TITLE
Raise wall image upload limit to 20 MB

### DIFF
--- a/src/main/kotlin/com/example/climbingapi/service/WallService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/WallService.kt
@@ -102,13 +102,13 @@ class WallService(
             throw IllegalArgumentException("Unsupported image type. Allowed: image/jpeg, image/png, image/webp.")
         }
         if (image.size > MAX_IMAGE_BYTES) {
-            throw PayloadTooLargeException("Image exceeds the maximum size of 5 MB.")
+            throw PayloadTooLargeException("Image exceeds the maximum size of 20 MB.")
         }
         return storageService.upload(image.bytes, contentType)
     }
 
     companion object {
         private val ALLOWED_IMAGE_TYPES = setOf("image/jpeg", "image/png", "image/webp")
-        private const val MAX_IMAGE_BYTES = 5L * 1024 * 1024
+        private const val MAX_IMAGE_BYTES = 20L * 1024 * 1024
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,8 +19,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 5MB
-      max-request-size: 6MB
+      max-file-size: 20MB
+      max-request-size: 21MB
 
   security:
     oauth2:

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -278,12 +278,12 @@ class WallControllerIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `PUT wall image exceeding 5MB returns 413`() {
+    fun `PUT wall image exceeding 20MB returns 413`() {
         postJson(baseUrl, """{"areaId":$areaId,"name":"North Face"}""")
 
         mockMvc.perform(
             multipart(HttpMethod.PUT, "$baseUrl/1/image")
-                .file(imagePart("big.jpg", "image/jpeg", ByteArray(5 * 1024 * 1024 + 1))).with(adminJwt())
+                .file(imagePart("big.jpg", "image/jpeg", ByteArray(20 * 1024 * 1024 + 1))).with(adminJwt())
         )
             .andExpect(status().isPayloadTooLarge)
             .andExpect(jsonPath("$.errorCode").value("PAYLOAD_TOO_LARGE"))


### PR DESCRIPTION
## What

- `WallService.MAX_IMAGE_BYTES`: 5 MB → 20 MB (and the 413 message text)
- `spring.servlet.multipart`: `max-file-size` 5MB → 20MB, `max-request-size` 6MB → 21MB (keeps the 1 MB headroom for the multipart envelope)
- `WallControllerIT`: oversized-upload test now sends 20 MB + 1

## Why

Modern phone photos routinely exceed 5 MB, so real topo uploads were bouncing off the 413. Closes #53.

## Coordination

The frontend mirrors the limit client-side; its constant and error copy change in lockstep on 585011/climbing-web#35.

`WallControllerIT` run green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)