### PR TITLE
Pass R2 env vars into the api container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
       AUTH0_ISSUER_URI: ${AUTH0_ISSUER_URI}
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
+      R2_ENDPOINT: ${R2_ENDPOINT}
+      R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID}
+      R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY}
+      R2_BUCKET: ${R2_BUCKET}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What

Adds the four `R2_*` variables to the `api` service's `environment:` block in `docker-compose.yml`, same passthrough style as the existing `AUTH0_*` vars.

## Why

Since #44 the app reads `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_BUCKET` at startup (unguarded `${...}` placeholders in `application.yaml`), but compose never forwarded them — so a locally composed api container can't boot on current main unless you export the vars some other way. Values come from `.env` as usual (see `.env.example` lines 30–33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)