### PR TITLE
Run api container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,13 @@ RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre
 
+RUN useradd --system --no-create-home --uid 1001 appuser
+
 WORKDIR /app
 
 COPY --from=builder /app/build/libs/*.jar app.jar
+
+USER appuser
 
 EXPOSE 8080
 


### PR DESCRIPTION
Adds a system user (uid 1001) to the runtime stage and switches to it before ENTRYPOINT — limits blast radius if the JVM process is ever compromised. Security review finding F-4.

Verified locally: image rebuilds, container runs as `uid=1001(appuser)`, Spring Boot starts cleanly, API responds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)