### PR TITLE
Fix WallServiceTest fixture missed by the 20 MB limit raise

### DIFF
--- a/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
@@ -112,7 +112,7 @@ class WallServiceTest {
     fun `create with oversized image throws PayloadTooLargeException`() {
         val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
             latitude = null, longitude = null, approachInfo = null)
-        val big = MockMultipartFile("image", "big.jpg", "image/jpeg", ByteArray(5 * 1024 * 1024 + 1))
+        val big = MockMultipartFile("image", "big.jpg", "image/jpeg", ByteArray(20 * 1024 * 1024 + 1))
         assertThrows(PayloadTooLargeException::class.java) { wallService.create(request, big) }
     }
 


### PR DESCRIPTION
PR #54 raised the upload limit and updated `WallControllerIT`, but missed the unit-level boundary test in `WallServiceTest` — CI on main caught it. Fixture now sends 20 MB + 1. Full `./gradlew build` green locally (151 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)