### PR TITLE
CD pipeline: GHCR image + SSH deploy to Hetzner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,10 @@ jobs:
         run: |
           for i in $(seq 1 24); do
             code=$(curl -s -o /dev/null -w '%{http_code}' "https://${{ vars.PROD_DOMAIN }}/api/climbing-areas") || code=000
-            if [ "$code" = "200" ]; then echo "Healthy"; exit 0; fi
+            # 401 = app is up but endpoint needs a JWT (anyRequest().authenticated()
+            # in SecurityConfig) — the app only answers after full startup, so it
+            # counts as healthy. 200 kept in case endpoints become public later.
+            if [ "$code" = "200" ] || [ "$code" = "401" ]; then echo "Healthy (HTTP $code)"; exit 0; fi
             echo "Attempt $i: HTTP $code — retrying in 5s"
             sleep 5
           done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Health check
         run: |
           for i in $(seq 1 24); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' "https://${{ vars.PROD_DOMAIN }}/api/climbing-areas") || code=000
+            code=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' "https://${{ vars.PROD_DOMAIN }}/api/climbing-areas") || code=000
             # 401 = app is up but endpoint needs a JWT (anyRequest().authenticated()
             # in SecurityConfig) — the app only answers after full startup, so it
             # counts as healthy. 200 kept in case endpoints become public later.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+      - run: chmod +x ./gradlew
+      - run: ./gradlew build
+
+  build-push:
+    needs: test
+    if: github.repository_owner == '585011'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/585011/climbing-api:latest
+            ghcr.io/585011/climbing-api:${{ github.sha }}
+
+  deploy:
+    needs: build-push
+    if: github.repository_owner == '585011'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
+            'cd /opt/climbing && docker compose pull api && docker compose up -d api'
+      - name: Health check
+        run: |
+          for i in $(seq 1 24); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "https://${{ vars.PROD_DOMAIN }}/api/climbing-areas") || code=000
+            if [ "$code" = "200" ]; then echo "Healthy"; exit 0; fi
+            echo "Attempt $i: HTTP $code — retrying in 5s"
+            sleep 5
+          done
+          echo "Health check failed after 120s"
+          exit 1


### PR DESCRIPTION
Closes #39.

- Adds `.github/workflows/deploy.yml`: gradle build (tests) → GHCR push (`latest` + sha) → SSH deploy of the `api` compose service → health check against `/api/climbing-areas` accepting 200 or 401 (all endpoints require a JWT, so an unauthenticated poll seeing 401 proves full startup, Flyway included)
- Existing `gradle.yml` CI is unchanged

Deployment config lives in https://github.com/585011/climbing-deploy (private) — see its README for the one-time VM/DNS/secrets setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)