### PR TITLE
feat: wall image variants (thumbnail + optimized) — issue #50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'net.coobird:thumbnailator:0.4.20'
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/WallController.kt
@@ -107,6 +107,10 @@ class WallController(
     fun update(@PathVariable id: Int, @Valid @RequestBody request: UpdateWallRequest): WallResponse =
         wallMapper.toResponse(wallService.update(id, request))
 
+    @Operation(summary = "Regenerate image variants for walls missing them (admin only)")
+    @PostMapping("/backfill-images")
+    fun backfillImages(): WallService.BackfillResult = wallService.backfillImages()
+
     @Operation(summary = "Delete a wall")
     @ApiResponse(responseCode = "204", description = "Wall deleted")
     @ApiResponse(responseCode = "404", description = "Wall not found",

--- a/src/main/kotlin/com/example/climbingapi/dto/WallResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/WallResponse.kt
@@ -12,5 +12,6 @@ data class WallResponse(
     val longitude: BigDecimal?,
     val approachInfo: String?,
     val imageUrl: String?,
+    val thumbnailUrl: String?,
     val createdAt: OffsetDateTime
 )

--- a/src/main/kotlin/com/example/climbingapi/mapper/WallMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/WallMapper.kt
@@ -19,7 +19,8 @@ class WallMapper(
             latitude = wall.latitude,
             longitude = wall.longitude,
             approachInfo = wall.approachInfo,
-            imageUrl = wall.imageKey?.let { storageService.presignGet(it) },
+            imageUrl = (wall.optimizedKey ?: wall.imageKey)?.let { storageService.presignGet(it) },
+            thumbnailUrl = (wall.thumbnailKey ?: wall.imageKey)?.let { storageService.presignGet(it) },
             createdAt = wall.createdAt!!
         )
     }

--- a/src/main/kotlin/com/example/climbingapi/model/Wall.kt
+++ b/src/main/kotlin/com/example/climbingapi/model/Wall.kt
@@ -12,5 +12,7 @@ data class Wall(
     val longitude: BigDecimal?,
     val approachInfo: String?,
     val imageKey: String?,
-    val createdAt: OffsetDateTime?
+    val createdAt: OffsetDateTime?,
+    val optimizedKey: String? = null,
+    val thumbnailKey: String? = null
 )

--- a/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
@@ -23,7 +23,9 @@ class WallRepository(
             longitude = rs.getBigDecimal("longitude"),
             approachInfo = rs.getString("approach_info"),
             imageKey = rs.getString("image_key"),
-            createdAt = createdTime
+            createdAt = createdTime,
+            optimizedKey = rs.getString("optimized_key"),
+            thumbnailKey = rs.getString("thumbnail_key")
         )
     }
 
@@ -38,7 +40,9 @@ class WallRepository(
                 longitude,
                 approach_info,
                 image_key,
-                created_at
+                created_at,
+                optimized_key,
+                thumbnail_key
             FROM walls
             ORDER BY id
             LIMIT ? OFFSET ?
@@ -61,7 +65,9 @@ class WallRepository(
                 longitude,
                 approach_info,
                 image_key,
-                created_at
+                created_at,
+                optimized_key,
+                thumbnail_key
             FROM walls
             WHERE id = ?
         """.trimIndent()
@@ -91,7 +97,9 @@ class WallRepository(
                       longitude,
                       approach_info,
                       image_key,
-                      created_at
+                      created_at,
+                      optimized_key,
+                      thumbnail_key
         """.trimIndent()
         return jdbcTemplate.query(
             sql,
@@ -119,9 +127,22 @@ class WallRepository(
                       longitude,
                       approach_info,
                       image_key,
-                      created_at
+                      created_at,
+                      optimized_key,
+                      thumbnail_key
         """.trimIndent()
         return jdbcTemplate.query(sql, wallRowMapper, imageKey, id).firstOrNull()
+    }
+
+    fun updateImageKeys(id: Int, imageKey: String, optimizedKey: String, thumbnailKey: String): Wall? {
+        val sql = """
+            UPDATE walls
+            SET image_key = ?, optimized_key = ?, thumbnail_key = ?
+            WHERE id = ?
+            RETURNING id, area_id, name, description, latitude, longitude,
+                      approach_info, image_key, created_at, optimized_key, thumbnail_key
+        """.trimIndent()
+        return jdbcTemplate.query(sql, wallRowMapper, imageKey, optimizedKey, thumbnailKey, id).firstOrNull()
     }
 
     fun findByAreaId(areaId: Int): List<Wall> {
@@ -135,7 +156,9 @@ class WallRepository(
                 longitude,
                 approach_info,
                 image_key,
-                created_at
+                created_at,
+                optimized_key,
+                thumbnail_key
             FROM walls
             WHERE area_id = ?
             ORDER BY id
@@ -146,36 +169,31 @@ class WallRepository(
     fun create(wall: Wall): Wall {
         val sql = """
             INSERT INTO walls (
-                area_id,
-                name,
-                description,
-                latitude,
-                longitude,
-                approach_info,
-                image_key
+                area_id, name, description, latitude, longitude,
+                approach_info, image_key, optimized_key, thumbnail_key
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            RETURNING id,
-                      area_id,
-                      name,
-                      description,
-                      latitude,
-                      longitude,
-                      approach_info,
-                      image_key,
-                      created_at
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING id, area_id, name, description, latitude, longitude,
+                      approach_info, image_key, created_at, optimized_key, thumbnail_key
         """.trimIndent()
 
         return jdbcTemplate.query(
-            sql,
-            wallRowMapper,
-            wall.areaId,
-            wall.name,
-            wall.description,
-            wall.latitude,
-            wall.longitude,
-            wall.approachInfo,
-            wall.imageKey
+            sql, wallRowMapper,
+            wall.areaId, wall.name, wall.description, wall.latitude, wall.longitude,
+            wall.approachInfo, wall.imageKey, wall.optimizedKey, wall.thumbnailKey
         ).firstOrNull() ?: error("INSERT RETURNING returned no row")
+    }
+
+    fun findWallsNeedingBackfill(): List<Wall> {
+        val sql = """
+            SELECT
+                id, area_id, name, description, latitude, longitude,
+                approach_info, image_key, created_at, optimized_key, thumbnail_key
+            FROM walls
+            WHERE image_key IS NOT NULL
+              AND (optimized_key IS NULL OR thumbnail_key IS NULL)
+            ORDER BY id
+        """.trimIndent()
+        return jdbcTemplate.query(sql, wallRowMapper)
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/WallRepository.kt
@@ -114,26 +114,6 @@ class WallRepository(
         ).firstOrNull()
     }
 
-    fun updateImageKey(id: Int, imageKey: String): Wall? {
-        val sql = """
-            UPDATE walls
-            SET image_key = ?
-            WHERE id = ?
-            RETURNING id,
-                      area_id,
-                      name,
-                      description,
-                      latitude,
-                      longitude,
-                      approach_info,
-                      image_key,
-                      created_at,
-                      optimized_key,
-                      thumbnail_key
-        """.trimIndent()
-        return jdbcTemplate.query(sql, wallRowMapper, imageKey, id).firstOrNull()
-    }
-
     fun updateImageKeys(id: Int, imageKey: String, optimizedKey: String, thumbnailKey: String): Wall? {
         val sql = """
             UPDATE walls

--- a/src/main/kotlin/com/example/climbingapi/service/ImageVariantService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/ImageVariantService.kt
@@ -1,0 +1,64 @@
+package com.example.climbingapi.service
+
+import net.coobird.thumbnailator.Thumbnails
+import org.springframework.stereotype.Service
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+data class ImageVariants(
+    val optimized: ByteArray,
+    val thumbnail: ByteArray,
+    val contentType: String
+)
+
+/**
+ * Produces resized JPEG variants of an uploaded image: a small thumbnail for
+ * list views and an optimized full-size for detail views. The caller keeps the
+ * original separately.
+ */
+@Service
+class ImageVariantService {
+
+    fun generate(bytes: ByteArray, contentType: String): ImageVariants {
+        val source = try {
+            ImageIO.read(ByteArrayInputStream(bytes))
+        } catch (_: Exception) {
+            null
+        }
+
+        // ImageIO cannot decode WebP (and returns null for any unreadable input).
+        // WebP uploads are already small, so fall back to the original bytes for
+        // both variants rather than pulling in a native decoder.
+        if (source == null) {
+            if (contentType == "image/webp") {
+                return ImageVariants(optimized = bytes, thumbnail = bytes, contentType = contentType)
+            }
+            throw IllegalArgumentException("Could not decode image for processing.")
+        }
+
+        return ImageVariants(
+            optimized = resizeToJpeg(bytes, OPTIMIZED_MAX_WIDTH, OPTIMIZED_QUALITY, source.width),
+            thumbnail = resizeToJpeg(bytes, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY, source.width),
+            contentType = "image/jpeg"
+        )
+    }
+
+    private fun resizeToJpeg(bytes: ByteArray, maxWidth: Int, quality: Double, sourceWidth: Int): ByteArray {
+        val targetWidth = minOf(maxWidth, sourceWidth) // never upscale
+        val out = ByteArrayOutputStream()
+        Thumbnails.of(ByteArrayInputStream(bytes))
+            .width(targetWidth) // height is computed to preserve aspect ratio
+            .outputFormat("jpg")
+            .outputQuality(quality)
+            .toOutputStream(out)
+        return out.toByteArray()
+    }
+
+    companion object {
+        const val THUMBNAIL_MAX_WIDTH = 400
+        const val OPTIMIZED_MAX_WIDTH = 1080
+        const val THUMBNAIL_QUALITY = 0.80
+        const val OPTIMIZED_QUALITY = 0.82
+    }
+}

--- a/src/main/kotlin/com/example/climbingapi/service/ImageVariantService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/ImageVariantService.kt
@@ -22,31 +22,41 @@ data class ImageVariants(
 class ImageVariantService {
 
     fun generate(bytes: ByteArray, contentType: String): ImageVariants {
-        val source = try {
-            ImageIO.read(ByteArrayInputStream(bytes))
-        } catch (_: Exception) {
-            null
-        }
+        ImageIO.createImageInputStream(ByteArrayInputStream(bytes)).use { iis ->
+            val reader = if (iis == null) null else ImageIO.getImageReaders(iis).let { if (it.hasNext()) it.next() else null }
 
-        // ImageIO cannot decode WebP (and returns null for any unreadable input).
-        // WebP uploads are already small, so fall back to the original bytes for
-        // both variants rather than pulling in a native decoder.
-        if (source == null) {
-            if (contentType == "image/webp") {
-                return ImageVariants(optimized = bytes, thumbnail = bytes, contentType = contentType)
+            // ImageIO cannot decode WebP (and has no reader for any unreadable input).
+            // WebP uploads are already small, so fall back to the original bytes for
+            // both variants rather than pulling in a native decoder.
+            if (reader == null) {
+                if (contentType == "image/webp") {
+                    return ImageVariants(optimized = bytes, thumbnail = bytes, contentType = contentType)
+                }
+                throw IllegalArgumentException("Could not decode image for processing.")
             }
-            throw IllegalArgumentException("Could not decode image for processing.")
-        }
 
-        if (exceedsPixelLimit(source.width, source.height)) {
-            throw IllegalArgumentException("Image dimensions too large to process.")
-        }
+            try {
+                reader.input = iis
+                val source = try {
+                    if (exceedsPixelLimit(reader.getWidth(0), reader.getHeight(0))) {
+                        throw IllegalArgumentException("Image dimensions too large to process.")
+                    }
+                    reader.read(0)
+                } catch (e: IllegalArgumentException) {
+                    throw e
+                } catch (e: Exception) {
+                    throw IllegalArgumentException("Could not decode image for processing.")
+                }
 
-        return ImageVariants(
-            optimized = resizeToJpeg(source, OPTIMIZED_MAX_WIDTH, OPTIMIZED_QUALITY),
-            thumbnail = resizeToJpeg(source, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY),
-            contentType = "image/jpeg"
-        )
+                return ImageVariants(
+                    optimized = resizeToJpeg(source, OPTIMIZED_MAX_WIDTH, OPTIMIZED_QUALITY),
+                    thumbnail = resizeToJpeg(source, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY),
+                    contentType = "image/jpeg"
+                )
+            } finally {
+                reader.dispose()
+            }
+        }
     }
 
     private fun resizeToJpeg(source: BufferedImage, maxWidth: Int, quality: Double): ByteArray {

--- a/src/main/kotlin/com/example/climbingapi/service/ImageVariantService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/ImageVariantService.kt
@@ -2,6 +2,7 @@ package com.example.climbingapi.service
 
 import net.coobird.thumbnailator.Thumbnails
 import org.springframework.stereotype.Service
+import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
@@ -37,17 +38,21 @@ class ImageVariantService {
             throw IllegalArgumentException("Could not decode image for processing.")
         }
 
+        if (exceedsPixelLimit(source.width, source.height)) {
+            throw IllegalArgumentException("Image dimensions too large to process.")
+        }
+
         return ImageVariants(
-            optimized = resizeToJpeg(bytes, OPTIMIZED_MAX_WIDTH, OPTIMIZED_QUALITY, source.width),
-            thumbnail = resizeToJpeg(bytes, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY, source.width),
+            optimized = resizeToJpeg(source, OPTIMIZED_MAX_WIDTH, OPTIMIZED_QUALITY),
+            thumbnail = resizeToJpeg(source, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY),
             contentType = "image/jpeg"
         )
     }
 
-    private fun resizeToJpeg(bytes: ByteArray, maxWidth: Int, quality: Double, sourceWidth: Int): ByteArray {
-        val targetWidth = minOf(maxWidth, sourceWidth) // never upscale
+    private fun resizeToJpeg(source: BufferedImage, maxWidth: Int, quality: Double): ByteArray {
+        val targetWidth = minOf(maxWidth, source.width) // never upscale
         val out = ByteArrayOutputStream()
-        Thumbnails.of(ByteArrayInputStream(bytes))
+        Thumbnails.of(source)
             .width(targetWidth) // height is computed to preserve aspect ratio
             .outputFormat("jpg")
             .outputQuality(quality)
@@ -55,10 +60,15 @@ class ImageVariantService {
         return out.toByteArray()
     }
 
+    /** True when width × height exceeds the safe decode limit (guards against decompression bombs). */
+    fun exceedsPixelLimit(width: Int, height: Int): Boolean =
+        width.toLong() * height.toLong() > MAX_SOURCE_PIXELS
+
     companion object {
         const val THUMBNAIL_MAX_WIDTH = 400
         const val OPTIMIZED_MAX_WIDTH = 1080
         const val THUMBNAIL_QUALITY = 0.80
         const val OPTIMIZED_QUALITY = 0.82
+        const val MAX_SOURCE_PIXELS = 50_000_000L // ~50 MP: generous for phone photos, blocks decode bombs
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/service/R2StorageService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/R2StorageService.kt
@@ -3,11 +3,13 @@ package com.example.climbingapi.service
 import com.example.climbingapi.config.R2Properties
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import software.amazon.awssdk.core.ResponseBytes
 import software.amazon.awssdk.core.exception.SdkException
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
@@ -50,6 +52,13 @@ class R2StorageService(
             .getObjectRequest(GetObjectRequest.builder().bucket(props.bucket).key(key).build())
             .build()
         return s3Presigner.presignGetObject(presignRequest).url().toString()
+    }
+
+    override fun get(key: String): ByteArray {
+        val response: ResponseBytes<GetObjectResponse> = s3Client.getObjectAsBytes(
+            GetObjectRequest.builder().bucket(props.bucket).key(key).build()
+        )
+        return response.asByteArray()
     }
 
     private fun extensionFor(contentType: String): String = when (contentType) {

--- a/src/main/kotlin/com/example/climbingapi/service/StorageService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/StorageService.kt
@@ -15,4 +15,7 @@ interface StorageService {
 
     /** Returns a short-lived presigned GET URL for the object key. */
     fun presignGet(key: String): String
+
+    /** Downloads the raw bytes for an object key (used to regenerate variants). */
+    fun get(key: String): ByteArray
 }

--- a/src/main/kotlin/com/example/climbingapi/service/WallService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/WallService.kt
@@ -104,14 +104,16 @@ class WallService(
         var failed = 0
         for (wall in wallRepository.findWallsNeedingBackfill()) {
             val originalKey = wall.imageKey ?: continue
+            var optimizedKey: String? = null
             try {
                 val bytes = storageService.get(originalKey)
                 val variants = imageVariantService.generate(bytes, contentTypeForKey(originalKey))
-                val optimizedKey = storageService.upload(variants.optimized, variants.contentType)
+                optimizedKey = storageService.upload(variants.optimized, variants.contentType)
                 val thumbnailKey = storageService.upload(variants.thumbnail, variants.contentType)
                 wallRepository.updateImageKeys(wall.id!!, originalKey, optimizedKey, thumbnailKey)
                 processed++
             } catch (e: Exception) {
+                optimizedKey?.let { storageService.delete(it) }
                 logger.warn("Backfill failed for wall {}: {}", wall.id, e.message)
                 failed++
             }
@@ -139,10 +141,16 @@ class WallService(
             throw PayloadTooLargeException("Image exceeds the maximum size of 20 MB.")
         }
         val variants = imageVariantService.generate(image.bytes, contentType)
-        val originalKey = storageService.upload(image.bytes, contentType)
-        val optimizedKey = storageService.upload(variants.optimized, variants.contentType)
-        val thumbnailKey = storageService.upload(variants.thumbnail, variants.contentType)
-        return StoredImage(originalKey, optimizedKey, thumbnailKey)
+        val uploaded = mutableListOf<String>()
+        try {
+            val originalKey = storageService.upload(image.bytes, contentType).also { uploaded += it }
+            val optimizedKey = storageService.upload(variants.optimized, variants.contentType).also { uploaded += it }
+            val thumbnailKey = storageService.upload(variants.thumbnail, variants.contentType).also { uploaded += it }
+            return StoredImage(originalKey, optimizedKey, thumbnailKey)
+        } catch (e: Exception) {
+            uploaded.forEach { storageService.delete(it) }
+            throw e
+        }
     }
 
     private fun deleteAll(s: StoredImage) {

--- a/src/main/kotlin/com/example/climbingapi/service/WallService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/WallService.kt
@@ -8,6 +8,7 @@ import com.example.climbingapi.exception.PayloadTooLargeException
 import com.example.climbingapi.model.Wall
 import com.example.climbingapi.model.Route
 import com.example.climbingapi.repository.WallRepository
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -16,7 +17,8 @@ import org.springframework.web.multipart.MultipartFile
 class WallService(
     private val wallRepository: WallRepository,
     private val routeService: RouteService,
-    private val storageService: StorageService
+    private val storageService: StorageService,
+    private val imageVariantService: ImageVariantService
 ) {
 
     fun getAll(page: Int, size: Int): PagedResponse<Wall> {
@@ -59,7 +61,7 @@ class WallService(
     }
 
     fun create(request: CreateWallRequest, image: MultipartFile? = null): Wall {
-        val imageKey = image?.let { uploadImage(it) }
+        val stored = image?.let { uploadImage(it) }
         val wall = Wall(
             id = null,
             areaId = request.areaId,
@@ -68,34 +70,66 @@ class WallService(
             latitude = request.latitude,
             longitude = request.longitude,
             approachInfo = request.approachInfo,
-            imageKey = imageKey,
-            createdAt = null
+            imageKey = stored?.originalKey,
+            createdAt = null,
+            optimizedKey = stored?.optimizedKey,
+            thumbnailKey = stored?.thumbnailKey
         )
-
         return try {
             wallRepository.create(wall)
         } catch (e: Exception) {
-            // Compensate the orphaned object if the row insert fails (e.g. bad areaId FK).
-            imageKey?.let { storageService.delete(it) }
+            stored?.let { deleteAll(it) }
             throw e
         }
     }
 
     @Transactional
     fun replaceImage(id: Int, image: MultipartFile): Wall {
-        val oldKey = getById(id).imageKey
-        val newKey = uploadImage(image)
+        val existing = getById(id)
+        val stored = uploadImage(image)
         val updated = try {
-            wallRepository.updateImageKey(id, newKey) ?: throw NotFoundException("Wall not found: $id")
+            wallRepository.updateImageKeys(id, stored.originalKey, stored.optimizedKey, stored.thumbnailKey)
+                ?: throw NotFoundException("Wall not found: $id")
         } catch (e: Exception) {
-            storageService.delete(newKey)
+            deleteAll(stored)
             throw e
         }
-        oldKey?.let { storageService.delete(it) }
+        listOfNotNull(existing.imageKey, existing.optimizedKey, existing.thumbnailKey)
+            .forEach { storageService.delete(it) }
         return updated
     }
 
-    private fun uploadImage(image: MultipartFile): String {
+    fun backfillImages(): BackfillResult {
+        var processed = 0
+        var failed = 0
+        for (wall in wallRepository.findWallsNeedingBackfill()) {
+            val originalKey = wall.imageKey ?: continue
+            try {
+                val bytes = storageService.get(originalKey)
+                val variants = imageVariantService.generate(bytes, contentTypeForKey(originalKey))
+                val optimizedKey = storageService.upload(variants.optimized, variants.contentType)
+                val thumbnailKey = storageService.upload(variants.thumbnail, variants.contentType)
+                wallRepository.updateImageKeys(wall.id!!, originalKey, optimizedKey, thumbnailKey)
+                processed++
+            } catch (e: Exception) {
+                logger.warn("Backfill failed for wall {}: {}", wall.id, e.message)
+                failed++
+            }
+        }
+        return BackfillResult(processed, failed)
+    }
+
+    private fun contentTypeForKey(key: String): String = when {
+        key.endsWith(".png") -> "image/png"
+        key.endsWith(".webp") -> "image/webp"
+        else -> "image/jpeg"
+    }
+
+    data class BackfillResult(val processed: Int, val failed: Int)
+
+    private data class StoredImage(val originalKey: String, val optimizedKey: String, val thumbnailKey: String)
+
+    private fun uploadImage(image: MultipartFile): StoredImage {
         if (image.isEmpty) throw IllegalArgumentException("Image file is empty.")
         val contentType = image.contentType
         if (contentType == null || contentType !in ALLOWED_IMAGE_TYPES) {
@@ -104,11 +138,22 @@ class WallService(
         if (image.size > MAX_IMAGE_BYTES) {
             throw PayloadTooLargeException("Image exceeds the maximum size of 20 MB.")
         }
-        return storageService.upload(image.bytes, contentType)
+        val variants = imageVariantService.generate(image.bytes, contentType)
+        val originalKey = storageService.upload(image.bytes, contentType)
+        val optimizedKey = storageService.upload(variants.optimized, variants.contentType)
+        val thumbnailKey = storageService.upload(variants.thumbnail, variants.contentType)
+        return StoredImage(originalKey, optimizedKey, thumbnailKey)
+    }
+
+    private fun deleteAll(s: StoredImage) {
+        storageService.delete(s.originalKey)
+        storageService.delete(s.optimizedKey)
+        storageService.delete(s.thumbnailKey)
     }
 
     companion object {
         private val ALLOWED_IMAGE_TYPES = setOf("image/jpeg", "image/png", "image/webp")
         private const val MAX_IMAGE_BYTES = 20L * 1024 * 1024
+        private val logger = LoggerFactory.getLogger(WallService::class.java)
     }
 }

--- a/src/main/resources/db/migration/V6__add_wall_image_variants.sql
+++ b/src/main/resources/db/migration/V6__add_wall_image_variants.sql
@@ -1,0 +1,3 @@
+ALTER TABLE walls
+    ADD COLUMN optimized_key varchar,
+    ADD COLUMN thumbnail_key varchar;

--- a/src/main/resources/db/migration/V6__add_wall_image_variants.sql
+++ b/src/main/resources/db/migration/V6__add_wall_image_variants.sql
@@ -1,3 +1,3 @@
 ALTER TABLE walls
-    ADD COLUMN optimized_key varchar,
-    ADD COLUMN thumbnail_key varchar;
+    ADD COLUMN optimized_key VARCHAR(512),
+    ADD COLUMN thumbnail_key VARCHAR(512);

--- a/src/test/kotlin/com/example/climbingapi/ImageVariantServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/ImageVariantServiceTest.kt
@@ -76,4 +76,11 @@ class ImageVariantServiceTest {
             service.generate(byteArrayOf(1, 2, 3, 4), "image/png")
         }
     }
+
+    @Test
+    fun `exceedsPixelLimit flags images over the cap and passes normal ones`() {
+        // Uses plain ints — does NOT allocate a giant image.
+        org.junit.jupiter.api.Assertions.assertTrue(service.exceedsPixelLimit(10_000, 6_000))   // 60 MP > cap
+        org.junit.jupiter.api.Assertions.assertFalse(service.exceedsPixelLimit(4_000, 3_000))   // 12 MP < cap
+    }
 }

--- a/src/test/kotlin/com/example/climbingapi/ImageVariantServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/ImageVariantServiceTest.kt
@@ -1,0 +1,79 @@
+package com.example.climbingapi
+
+import com.example.climbingapi.service.ImageVariantService
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+class ImageVariantServiceTest {
+
+    private val service = ImageVariantService()
+
+    // A 2000x1000 opaque PNG — larger than both variant width caps.
+    private fun largePngBytes(): ByteArray {
+        val img = BufferedImage(2000, 1000, BufferedImage.TYPE_INT_RGB)
+        val g = img.createGraphics()
+        g.color = java.awt.Color(120, 80, 60)
+        g.fillRect(0, 0, 2000, 1000)
+        g.dispose()
+        val out = ByteArrayOutputStream()
+        ImageIO.write(img, "png", out)
+        return out.toByteArray()
+    }
+
+    private fun widthOf(bytes: ByteArray): Int =
+        ImageIO.read(ByteArrayInputStream(bytes)).width
+
+    @Test
+    fun `generate downsizes to the variant width caps and outputs jpeg`() {
+        val variants = service.generate(largePngBytes(), "image/png")
+
+        assertEquals("image/jpeg", variants.contentType)
+        assertEquals(ImageVariantService.THUMBNAIL_MAX_WIDTH, widthOf(variants.thumbnail))
+        assertEquals(ImageVariantService.OPTIMIZED_MAX_WIDTH, widthOf(variants.optimized))
+        // Both variants must be far smaller than the source bytes.
+        assertTrue(variants.thumbnail.size < variants.optimized.size)
+    }
+
+    @Test
+    fun `generate preserves aspect ratio`() {
+        val variants = service.generate(largePngBytes(), "image/png")
+        val thumb = ImageIO.read(ByteArrayInputStream(variants.thumbnail))
+        // source is 2:1, so a 400px-wide thumbnail is 200px tall.
+        assertEquals(200, thumb.height)
+    }
+
+    @Test
+    fun `generate does not upscale a source smaller than the caps`() {
+        val small = BufferedImage(150, 150, BufferedImage.TYPE_INT_RGB)
+        val out = ByteArrayOutputStream()
+        ImageIO.write(small, "png", out)
+
+        val variants = service.generate(out.toByteArray(), "image/png")
+        assertEquals(150, widthOf(variants.optimized))
+        assertEquals(150, widthOf(variants.thumbnail))
+    }
+
+    @Test
+    fun `generate falls back to original bytes for undecodable webp input`() {
+        val webpBytes = byteArrayOf(1, 2, 3, 4) // not decodable by ImageIO
+        val variants = service.generate(webpBytes, "image/webp")
+
+        assertEquals("image/webp", variants.contentType)
+        assertArrayEquals(webpBytes, variants.optimized)
+        assertArrayEquals(webpBytes, variants.thumbnail)
+    }
+
+    @Test
+    fun `generate throws on undecodable non-webp input`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            service.generate(byteArrayOf(1, 2, 3, 4), "image/png")
+        }
+    }
+}

--- a/src/test/kotlin/com/example/climbingapi/WallMapperTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/WallMapperTest.kt
@@ -1,0 +1,52 @@
+package com.example.climbingapi
+
+import com.example.climbingapi.mapper.WallMapper
+import com.example.climbingapi.model.Wall
+import com.example.climbingapi.service.StorageService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.OffsetDateTime
+
+@ExtendWith(MockitoExtension::class)
+class WallMapperTest {
+
+    @Mock lateinit var storageService: StorageService
+
+    private fun mapper() = WallMapper(storageService)
+
+    @Test
+    fun `imageUrl prefers optimized key, thumbnailUrl prefers thumbnail key`() {
+        lenient().`when`(storageService.presignGet("opt")).thenReturn("http://opt")
+        lenient().`when`(storageService.presignGet("thumb")).thenReturn("http://thumb")
+        val wall = Wall(1, 1, "W", null, null, null, null, "orig", OffsetDateTime.now(), "opt", "thumb")
+
+        val res = mapper().toResponse(wall)
+
+        assertEquals("http://opt", res.imageUrl)
+        assertEquals("http://thumb", res.thumbnailUrl)
+    }
+
+    @Test
+    fun `falls back to the original key when variants are missing`() {
+        lenient().`when`(storageService.presignGet("orig")).thenReturn("http://orig")
+        val wall = Wall(1, 1, "W", null, null, null, null, "orig", OffsetDateTime.now())
+
+        val res = mapper().toResponse(wall)
+
+        assertEquals("http://orig", res.imageUrl)
+        assertEquals("http://orig", res.thumbnailUrl)
+    }
+
+    @Test
+    fun `null image produces null urls`() {
+        val wall = Wall(1, 1, "W", null, null, null, null, null, OffsetDateTime.now())
+        val res = mapper().toResponse(wall)
+        assertNull(res.imageUrl)
+        assertNull(res.thumbnailUrl)
+    }
+}

--- a/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
@@ -113,6 +113,18 @@ class WallServiceTest {
     }
 
     @Test
+    fun `create with image deletes already-uploaded object when a later upload fails`() {
+        val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any()))
+            .thenReturn("walls/orig").thenThrow(RuntimeException("r2 down"))
+
+        assertThrows(RuntimeException::class.java) { wallService.create(request, jpeg) }
+        verify(storageService).delete("walls/orig")
+    }
+
+    @Test
     fun `create with unsupported image type throws IllegalArgumentException`() {
         val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
             latitude = null, longitude = null, approachInfo = null)

--- a/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/WallServiceTest.kt
@@ -7,6 +7,8 @@ import com.example.climbingapi.exception.PayloadTooLargeException
 import com.example.climbingapi.model.Route
 import com.example.climbingapi.model.Wall
 import com.example.climbingapi.repository.WallRepository
+import com.example.climbingapi.service.ImageVariantService
+import com.example.climbingapi.service.ImageVariants
 import com.example.climbingapi.service.RouteService
 import com.example.climbingapi.service.StorageService
 import com.example.climbingapi.service.WallService
@@ -14,13 +16,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.mock.web.MockMultipartFile
 import java.time.OffsetDateTime
+
+// Mockito's ArgumentMatchers.any() returns null, which Kotlin's non-null parameter
+// types reject at the call site (NPE). This wrapper works around that interop gap.
+private fun <T> any(): T = Mockito.any<T>()
 
 @ExtendWith(MockitoExtension::class)
 class WallServiceTest {
@@ -28,6 +36,7 @@ class WallServiceTest {
     @Mock lateinit var wallRepository: WallRepository
     @Mock lateinit var routeService: RouteService
     @Mock lateinit var storageService: StorageService
+    @Mock lateinit var imageVariantService: ImageVariantService
 
     @InjectMocks
     lateinit var wallService: WallService
@@ -35,6 +44,7 @@ class WallServiceTest {
     private val sampleWall = Wall(1, 1, "Main Wall", null, null, null, null, null, OffsetDateTime.now())
     private val sampleRoute = Route(1, 1, "Test Route", "6a", 20, "sport", 8, null, null, null, OffsetDateTime.now())
     private val jpeg = MockMultipartFile("image", "photo.jpg", "image/jpeg", byteArrayOf(1, 2, 3))
+    private val variants = ImageVariants(byteArrayOf(9), byteArrayOf(8), "image/jpeg")
 
     @Test
     fun `getById returns wall when found`() {
@@ -81,9 +91,9 @@ class WallServiceTest {
         val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
             latitude = null, longitude = null, approachInfo = null)
         val expected = sampleWall.copy(name = "Photo Wall", imageKey = "walls/abc.jpg")
-        `when`(storageService.upload(jpeg.bytes, "image/jpeg")).thenReturn("walls/abc.jpg")
-        `when`(wallRepository.create(Wall(null, 1, "Photo Wall", null, null, null, null, "walls/abc.jpg", null)))
-            .thenReturn(expected)
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("walls/abc.jpg", "walls/opt", "walls/thumb")
+        `when`(wallRepository.create(any())).thenReturn(expected)
 
         assertEquals(expected, wallService.create(request, jpeg))
     }
@@ -92,12 +102,14 @@ class WallServiceTest {
     fun `create with image deletes uploaded object when insert fails`() {
         val request = CreateWallRequest(areaId = 1, name = "Photo Wall", description = null,
             latitude = null, longitude = null, approachInfo = null)
-        `when`(storageService.upload(jpeg.bytes, "image/jpeg")).thenReturn("walls/abc.jpg")
-        `when`(wallRepository.create(Wall(null, 1, "Photo Wall", null, null, null, null, "walls/abc.jpg", null)))
-            .thenThrow(RuntimeException("insert failed"))
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("walls/abc.jpg", "walls/opt", "walls/thumb")
+        `when`(wallRepository.create(any())).thenThrow(RuntimeException("insert failed"))
 
         assertThrows(RuntimeException::class.java) { wallService.create(request, jpeg) }
         verify(storageService).delete("walls/abc.jpg")
+        verify(storageService).delete("walls/opt")
+        verify(storageService).delete("walls/thumb")
     }
 
     @Test
@@ -120,8 +132,10 @@ class WallServiceTest {
     fun `replaceImage uploads new key, updates wall, and deletes old object`() {
         val png = MockMultipartFile("image", "photo.png", "image/png", byteArrayOf(4, 5, 6))
         `when`(wallRepository.getById(1)).thenReturn(sampleWall.copy(imageKey = "old-key"))
-        `when`(storageService.upload(png.bytes, "image/png")).thenReturn("new-key")
-        `when`(wallRepository.updateImageKey(1, "new-key")).thenReturn(sampleWall.copy(imageKey = "new-key"))
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("new-key", "new-opt", "new-thumb")
+        `when`(wallRepository.updateImageKeys(1, "new-key", "new-opt", "new-thumb"))
+            .thenReturn(sampleWall.copy(imageKey = "new-key"))
 
         val result = wallService.replaceImage(1, png)
 
@@ -133,6 +147,77 @@ class WallServiceTest {
     fun `replaceImage on missing wall throws NotFoundException`() {
         `when`(wallRepository.getById(99)).thenReturn(null)
         assertThrows(NotFoundException::class.java) { wallService.replaceImage(99, jpeg) }
+    }
+
+    @Test
+    fun `create stores original, optimized, and thumbnail keys`() {
+        val request = CreateWallRequest(areaId = 1, name = "W", description = null,
+            latitude = null, longitude = null, approachInfo = null)
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("walls/orig", "walls/opt", "walls/thumb")
+        var captured: Wall? = null
+        `when`(wallRepository.create(any())).thenAnswer {
+            captured = it.getArgument(0)
+            captured
+        }
+
+        wallService.create(request, jpeg)
+
+        assertEquals("walls/orig", captured?.imageKey)
+        assertEquals("walls/opt", captured?.optimizedKey)
+        assertEquals("walls/thumb", captured?.thumbnailKey)
+    }
+
+    @Test
+    fun `replaceImage deletes the three old keys after a successful swap`() {
+        val old = Wall(1, 1, "W", null, null, null, null, "walls/oldO", OffsetDateTime.now(),
+            "walls/oldOpt", "walls/oldThumb")
+        `when`(wallRepository.getById(1)).thenReturn(old)
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("walls/newO", "walls/newOpt", "walls/newThumb")
+        `when`(wallRepository.updateImageKeys(1, "walls/newO", "walls/newOpt", "walls/newThumb"))
+            .thenReturn(old.copy(imageKey = "walls/newO"))
+
+        wallService.replaceImage(1, jpeg)
+
+        verify(storageService).delete("walls/oldO")
+        verify(storageService).delete("walls/oldOpt")
+        verify(storageService).delete("walls/oldThumb")
+    }
+
+    @Test
+    fun `backfillImages processes only walls missing variants and is idempotent on a second run`() {
+        val needs = Wall(5, 1, "W", null, null, null, null, "walls/orig.png", OffsetDateTime.now())
+        `when`(wallRepository.findWallsNeedingBackfill()).thenReturn(listOf(needs), emptyList())
+        `when`(storageService.get("walls/orig.png")).thenReturn(byteArrayOf(1))
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("walls/opt", "walls/thumb")
+        `when`(wallRepository.updateImageKeys(5, "walls/orig.png", "walls/opt", "walls/thumb"))
+            .thenReturn(needs)
+
+        val first = wallService.backfillImages()
+        val second = wallService.backfillImages()
+
+        assertEquals(1, first.processed)
+        assertEquals(0, first.failed)
+        assertEquals(0, second.processed)
+    }
+
+    @Test
+    fun `backfillImages counts a per-wall failure without aborting`() {
+        val a = Wall(6, 1, "A", null, null, null, null, "walls/a.png", OffsetDateTime.now())
+        val b = Wall(7, 1, "B", null, null, null, null, "walls/b.png", OffsetDateTime.now())
+        `when`(wallRepository.findWallsNeedingBackfill()).thenReturn(listOf(a, b))
+        `when`(storageService.get("walls/a.png")).thenThrow(RuntimeException("boom"))
+        `when`(storageService.get("walls/b.png")).thenReturn(byteArrayOf(1))
+        `when`(imageVariantService.generate(any(), any())).thenReturn(variants)
+        `when`(storageService.upload(any(), any())).thenReturn("walls/opt", "walls/thumb")
+        `when`(wallRepository.updateImageKeys(eq(7), any(), any(), any())).thenReturn(b)
+
+        val result = wallService.backfillImages()
+
+        assertEquals(1, result.processed)
+        assertEquals(1, result.failed)
     }
 
     @Test

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -308,4 +308,20 @@ class WallControllerIT : IntegrationTestBase() {
         )
             .andExpect(status().isForbidden)
     }
+
+    @Test
+    fun `backfill requires admin`() {
+        mockMvc.perform(post("$baseUrl/backfill-images"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `backfill as admin returns processed and failed counts`() {
+        mockMvc.perform(
+            post("$baseUrl/backfill-images").with(adminJwt())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.processed").exists())
+            .andExpect(jsonPath("$.failed").exists())
+    }
 }

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -42,6 +42,8 @@ class WallControllerIT : IntegrationTestBase() {
             override fun delete(key: String) { /* no-op */ }
 
             override fun presignGet(key: String): String = "https://fake-r2.local/$key?signed=true"
+
+            override fun get(key: String): ByteArray = ByteArray(0)
         }
     }
 

--- a/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallControllerIT.kt
@@ -224,7 +224,14 @@ class WallControllerIT : IntegrationTestBase() {
     private fun wallPart(name: String = "Photo Wall") =
         MockMultipartFile("wall", "", MediaType.APPLICATION_JSON_VALUE, """{"areaId":$areaId,"name":"$name"}""".toByteArray())
 
-    private fun imagePart(filename: String = "photo.jpg", type: String = "image/jpeg", bytes: ByteArray = byteArrayOf(1, 2, 3)) =
+    private fun realImageBytes(): ByteArray {
+        val img = java.awt.image.BufferedImage(120, 80, java.awt.image.BufferedImage.TYPE_INT_RGB)
+        val out = java.io.ByteArrayOutputStream()
+        javax.imageio.ImageIO.write(img, "png", out)
+        return out.toByteArray()
+    }
+
+    private fun imagePart(filename: String = "photo.jpg", type: String = "image/jpeg", bytes: ByteArray = realImageBytes()) =
         MockMultipartFile("image", filename, type, bytes)
 
     @Test

--- a/src/test/kotlin/com/example/climbingapi/integration/WallRepositoryIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/WallRepositoryIT.kt
@@ -1,0 +1,80 @@
+package com.example.climbingapi.integration
+
+import com.example.climbingapi.model.Wall
+import com.example.climbingapi.repository.WallRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+
+@Import(WallControllerIT.FakeStorageConfig::class)
+class WallRepositoryIT : IntegrationTestBase() {
+
+    @Autowired lateinit var wallRepository: WallRepository
+
+    private var areaId = 0
+
+    @BeforeEach
+    fun createArea() {
+        // resetDatabase() in IntegrationTestBase truncates everything first (runs before this).
+        areaId = extractId(postJson("/api/climbing-areas", """{"name":"Test Area"}"""))
+    }
+
+    @Test
+    fun `create and read round-trips all three image keys`() {
+        val created = wallRepository.create(
+            Wall(
+                id = null, areaId = areaId, name = "Variant Wall", description = null,
+                latitude = null, longitude = null, approachInfo = null,
+                imageKey = "walls/orig.png", createdAt = null,
+                optimizedKey = "walls/opt.jpg", thumbnailKey = "walls/thumb.jpg"
+            )
+        )
+        val fetched = wallRepository.getById(created.id!!)
+        assertNotNull(fetched)
+        assertEquals("walls/orig.png", fetched!!.imageKey)
+        assertEquals("walls/opt.jpg", fetched.optimizedKey)
+        assertEquals("walls/thumb.jpg", fetched.thumbnailKey)
+    }
+
+    @Test
+    fun `updateImageKeys replaces all three keys`() {
+        val created = wallRepository.create(
+            Wall(
+                id = null, areaId = areaId, name = "Update Wall", description = null,
+                latitude = null, longitude = null, approachInfo = null,
+                imageKey = "walls/old.png", createdAt = null
+            )
+        )
+        val updated = wallRepository.updateImageKeys(created.id!!, "walls/o2.png", "walls/opt2.jpg", "walls/th2.jpg")
+        assertNotNull(updated)
+        assertEquals("walls/o2.png", updated!!.imageKey)
+        assertEquals("walls/opt2.jpg", updated.optimizedKey)
+        assertEquals("walls/th2.jpg", updated.thumbnailKey)
+    }
+
+    @Test
+    fun `findWallsNeedingBackfill returns walls with an original but missing variants`() {
+        val needs = wallRepository.create(
+            Wall(
+                id = null, areaId = areaId, name = "Needs Backfill", description = null,
+                latitude = null, longitude = null, approachInfo = null,
+                imageKey = "walls/needs.png", createdAt = null
+            )
+        )
+        val done = wallRepository.create(
+            Wall(
+                id = null, areaId = areaId, name = "Already Done", description = null,
+                latitude = null, longitude = null, approachInfo = null,
+                imageKey = "walls/done.png", createdAt = null,
+                optimizedKey = "walls/done-opt.jpg", thumbnailKey = "walls/done-th.jpg"
+            )
+        )
+        val result = wallRepository.findWallsNeedingBackfill()
+        assertTrue(result.any { it.id == needs.id })
+        assertTrue(result.none { it.id == done.id })
+    }
+}


### PR DESCRIPTION
Backend half of the image-performance fix ([climbing-web#50](https://github.com/585011/climbing-web/issues/50)). Wall images were stored/served as multi-MB originals and crammed into ~72px list thumbnails.

## What changes

On upload, generate two resized **JPEG** variants (Thumbnailator, pure-JVM — no native binary) and keep the original:
- **thumbnail** ~400px q0.80 (crag list) · **optimized** ~1080px q0.82 (wall/area hero)
- Three R2 object keys per wall (`image_key` = original, `optimized_key`, `thumbnail_key`, migration V6, all nullable).
- `WallResponse` gains `thumbnailUrl`; `imageUrl = presign(optimizedKey ?: imageKey)`, `thumbnailUrl = presign(thumbnailKey ?: imageKey)` — unprocessed walls still render (at original size) until backfilled.
- Admin-only `POST /api/walls/backfill-images` (guarded by the existing `POST /api/walls/**` admin matcher — no security change) regenerates variants for pre-existing images; idempotent, per-wall failures logged + counted, returns `{processed, failed}`.

## Safety / hardening
- Original is always kept and never overwritten by a variant.
- Partial-upload cleanup: a failed 2nd/3rd R2 upload deletes the already-stored objects (no orphans); same in backfill.
- Decompression-bomb guard: image dimensions are read from the **header** and rejected (> ~50MP, overflow-safe `Long` check) **before** the full decode allocates.
- WebP input (ImageIO can't decode) falls back to the original bytes; other undecodable input → 400. No secrets introduced; error responses stay generic.

## Testing
- Full suite **170 / 0 failed / 1 pre-existing skip** (JUnit5 + Mockito + Testcontainers).
- New coverage: variant sizing/aspect/no-upscale/webp-fallback/pixel-cap, repository 3-key round-trip + backfill query, mapper URL fallbacks, service 3-object store + compensation + backfill idempotency + partial-upload cleanup, controller admin-guard + counts.
- Built via subagent-driven-development: per-task spec+quality reviews + a whole-branch review; 2 review findings (R2 orphan leak, decode-before-guard ordering) fixed and re-reviewed clean.

## Deploy
After merge: run once with an admin token — `curl -X POST https://<api-host>/api/walls/backfill-images -H "Authorization: Bearer <admin-jwt>"`.

Frontend counterpart (serve `thumbnailUrl` on the crag list) ships as a separate climbing-web PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)