### PR TITLE
feat: add /health endpoint for Railway healthcheck

### DIFF
--- a/src/main/kotlin/com/example/climbingapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/climbingapi/config/SecurityConfig.kt
@@ -52,6 +52,7 @@ class SecurityConfig(
                 headers.xssProtection { it.disable() }
             }
             .authorizeHttpRequests {
+                it.requestMatchers(HttpMethod.GET, "/health").permitAll()
                 it.requestMatchers(HttpMethod.POST, "/api/climbing-areas/**", "/api/walls/**", "/api/routes/**").hasRole("admin")
                 it.requestMatchers(HttpMethod.PUT, "/api/climbing-areas/**", "/api/walls/**", "/api/routes/**").hasRole("admin")
                 it.requestMatchers(HttpMethod.DELETE, "/api/climbing-areas/**", "/api/walls/**", "/api/routes/**").hasRole("admin")

--- a/src/main/kotlin/com/example/climbingapi/controller/HealthController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/HealthController.kt
@@ -1,0 +1,15 @@
+package com.example.climbingapi.controller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Unauthenticated liveness probe for the platform (Railway healthcheck).
+ * Permitted in SecurityConfig; every other endpoint stays authenticated.
+ */
+@RestController
+class HealthController {
+
+    @GetMapping("/health")
+    fun health(): Map<String, String> = mapOf("status" to "UP")
+}


### PR DESCRIPTION
## What

- Add `HealthController` exposing unauthenticated `GET /health` → `200 {"status":"UP"}`.
- Permit `GET /health` in `SecurityConfig`; every other endpoint stays `authenticated()`.

## Why

Railway's deploy healthcheck hit an authenticated path and got `401`, so the deploy was marked unhealthy and failed at **Network > Healthcheck** (visible on the merge-#65 deployment). A public liveness endpoint lets the healthcheck pass without weakening auth anywhere else.

## Follow-up (Railway dashboard)

Set backend service → Settings → Deploy → **Healthcheck Path = `/health`**. Then redeploy — healthcheck goes green.

## Notes

- No CORS impact: CORS is registered only for `/api/**`; `/health` is server-to-server.
- `compileKotlin` passes locally; Kotlin CI (`gradle.yml`) covers the rest.