### PR TITLE
feat: expose routeCount on ClimbingAreaResponse

### DIFF
--- a/src/main/kotlin/com/example/climbingapi/controller/ClimbingAreaController.kt
+++ b/src/main/kotlin/com/example/climbingapi/controller/ClimbingAreaController.kt
@@ -49,7 +49,11 @@ class ClimbingAreaController(
         @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int
     ): PagedResponse<ClimbingAreaResponse> {
         val paged = climbingAreaService.getAll(page, size)
-        return PagedResponse(paged.data.map { climbingAreaMapper.toResponse(it) }, paged.page, paged.pageSize, paged.total)
+        val routeCounts = climbingAreaService.getRouteCounts(paged.data.mapNotNull { it.id })
+        return PagedResponse(
+            paged.data.map { climbingAreaMapper.toResponse(it, routeCounts[it.id] ?: 0) },
+            paged.page, paged.pageSize, paged.total
+        )
     }
 
     @Operation(summary = "Get a climbing area by ID")
@@ -57,7 +61,7 @@ class ClimbingAreaController(
         content = [Content(schema = Schema(implementation = ErrorResponse::class))])
     @GetMapping("/{id}")
     fun getById(@PathVariable id: Int): ClimbingAreaResponse =
-        climbingAreaMapper.toResponse(climbingAreaService.getById(id))
+        climbingAreaMapper.toResponse(climbingAreaService.getById(id), routeCountFor(id))
 
     @Operation(summary = "List walls for a climbing area")
     @ApiResponse(responseCode = "404", description = "Climbing area not found",
@@ -74,7 +78,7 @@ class ClimbingAreaController(
         @Valid @RequestBody request: CreateClimbingAreaRequest,
         ucb: UriComponentsBuilder
     ): ResponseEntity<ClimbingAreaResponse> {
-        val created = climbingAreaMapper.toResponse(climbingAreaService.create(request))
+        val created = climbingAreaMapper.toResponse(climbingAreaService.create(request), 0)
         val location = ucb.path("/api/climbing-areas/{id}").buildAndExpand(created.id).toUri()
         return ResponseEntity.created(location).body(created)
     }
@@ -86,7 +90,10 @@ class ClimbingAreaController(
         content = [Content(schema = Schema(implementation = ErrorResponse::class))])
     @PutMapping("/{id}")
     fun update(@PathVariable id: Int, @Valid @RequestBody request: UpdateClimbingAreaRequest): ClimbingAreaResponse =
-        climbingAreaMapper.toResponse(climbingAreaService.update(id, request))
+        climbingAreaMapper.toResponse(climbingAreaService.update(id, request), routeCountFor(id))
+
+    private fun routeCountFor(areaId: Int): Int =
+        climbingAreaService.getRouteCounts(listOf(areaId))[areaId] ?: 0
 
     @Operation(summary = "Delete a climbing area")
     @ApiResponse(responseCode = "204", description = "Climbing area deleted")

--- a/src/main/kotlin/com/example/climbingapi/dto/ClimbingAreaResponse.kt
+++ b/src/main/kotlin/com/example/climbingapi/dto/ClimbingAreaResponse.kt
@@ -10,5 +10,6 @@ data class ClimbingAreaResponse(
     val latitude: BigDecimal?,
     val longitude: BigDecimal?,
     val region: String?,
-    val createdAt: OffsetDateTime
+    val createdAt: OffsetDateTime,
+    val routeCount: Int
 )

--- a/src/main/kotlin/com/example/climbingapi/mapper/ClimbingAreaMapper.kt
+++ b/src/main/kotlin/com/example/climbingapi/mapper/ClimbingAreaMapper.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 @Component
 class ClimbingAreaMapper {
 
-    fun toResponse(area: ClimbingArea): ClimbingAreaResponse {
+    fun toResponse(area: ClimbingArea, routeCount: Int): ClimbingAreaResponse {
         return ClimbingAreaResponse(
             id = area.id!!,
             name = area.name!!,
@@ -15,7 +15,8 @@ class ClimbingAreaMapper {
             latitude = area.latitude,
             longitude = area.longitude,
             region = area.region,
-            createdAt = area.createdAt!!
+            createdAt = area.createdAt!!,
+            routeCount = routeCount
         )
     }
 }

--- a/src/main/kotlin/com/example/climbingapi/repository/RouteRepository.kt
+++ b/src/main/kotlin/com/example/climbingapi/repository/RouteRepository.kt
@@ -72,6 +72,23 @@ class RouteRepository(
         return jdbcTemplate.query(sql, routeRowMapper, id).firstOrNull()
     }
 
+    fun countByAreaIds(areaIds: List<Int>): Map<Int, Int> {
+        if (areaIds.isEmpty()) return emptyMap()
+        val placeholders = areaIds.joinToString(", ") { "?" }
+        val sql = """
+            SELECT w.area_id, COUNT(*) AS route_count
+            FROM routes r
+            JOIN walls w ON w.id = r.wall_id
+            WHERE w.area_id IN ($placeholders)
+            GROUP BY w.area_id
+        """.trimIndent()
+        return jdbcTemplate.query(
+            sql,
+            { rs, _ -> rs.getInt("area_id") to rs.getInt("route_count") },
+            *areaIds.toTypedArray()
+        ).toMap()
+    }
+
     fun findByWallId(wallId: Int): List<Route> {
         val sql = """
             SELECT id,

--- a/src/main/kotlin/com/example/climbingapi/service/ClimbingAreaService.kt
+++ b/src/main/kotlin/com/example/climbingapi/service/ClimbingAreaService.kt
@@ -7,12 +7,14 @@ import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.ClimbingArea
 import com.example.climbingapi.model.Wall
 import com.example.climbingapi.repository.ClimbingAreaRepository
+import com.example.climbingapi.repository.RouteRepository
 import org.springframework.stereotype.Service
 
 @Service
 class ClimbingAreaService(
     private val climbingAreaRepository: ClimbingAreaRepository,
-    private val wallService: WallService
+    private val wallService: WallService,
+    private val routeRepository: RouteRepository
 ) {
 
     fun getAll(page: Int, size: Int): PagedResponse<ClimbingArea> {
@@ -25,6 +27,10 @@ class ClimbingAreaService(
     fun getById(id: Int): ClimbingArea {
         return climbingAreaRepository.getById(id)
             ?: throw NotFoundException("Climbing area not found: $id")
+    }
+
+    fun getRouteCounts(areaIds: List<Int>): Map<Int, Int> {
+        return routeRepository.countByAreaIds(areaIds)
     }
 
     fun getWalls(climbingAreaId: Int): List<Wall> {

--- a/src/test/kotlin/com/example/climbingapi/ClimbingAreaServiceTest.kt
+++ b/src/test/kotlin/com/example/climbingapi/ClimbingAreaServiceTest.kt
@@ -6,6 +6,7 @@ import com.example.climbingapi.exception.NotFoundException
 import com.example.climbingapi.model.ClimbingArea
 import com.example.climbingapi.model.Wall
 import com.example.climbingapi.repository.ClimbingAreaRepository
+import com.example.climbingapi.repository.RouteRepository
 import com.example.climbingapi.service.ClimbingAreaService
 import com.example.climbingapi.service.WallService
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -23,6 +24,7 @@ class ClimbingAreaServiceTest {
 
     @Mock lateinit var climbingAreaRepository: ClimbingAreaRepository
     @Mock lateinit var wallService: WallService
+    @Mock lateinit var routeRepository: RouteRepository
 
     @InjectMocks
     lateinit var climbingAreaService: ClimbingAreaService
@@ -88,6 +90,12 @@ class ClimbingAreaServiceTest {
     fun `delete throws NotFoundException when area not found`() {
         `when`(climbingAreaRepository.deleteById(99)).thenReturn(false)
         assertThrows(NotFoundException::class.java) { climbingAreaService.delete(99) }
+    }
+
+    @Test
+    fun `getRouteCounts delegates to routeRepository`() {
+        `when`(routeRepository.countByAreaIds(listOf(1, 2))).thenReturn(mapOf(1 to 5, 2 to 0))
+        assertEquals(mapOf(1 to 5, 2 to 0), climbingAreaService.getRouteCounts(listOf(1, 2)))
     }
 
     @Test

--- a/src/test/kotlin/com/example/climbingapi/integration/ClimbingAreaControllerIT.kt
+++ b/src/test/kotlin/com/example/climbingapi/integration/ClimbingAreaControllerIT.kt
@@ -42,6 +42,26 @@ class ClimbingAreaControllerIT : IntegrationTestBase() {
     }
 
     @Test
+    fun `GET areas returns routeCount aggregated across walls`() {
+        postJson(baseUrl, validArea)
+        postJson(baseUrl, """{"name":"Other Area"}""")
+        postJson("/api/walls", """{"areaId":1,"name":"Wall A"}""")
+        postJson("/api/walls", """{"areaId":1,"name":"Wall B"}""")
+        postJson("/api/routes", """{"wallId":1,"name":"Route 1","grade":"6a"}""")
+        postJson("/api/routes", """{"wallId":1,"name":"Route 2","grade":"6b"}""")
+        postJson("/api/routes", """{"wallId":2,"name":"Route 3","grade":"7a"}""")
+
+        mockMvc.perform(get(baseUrl).with(testJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data[0].routeCount").value(3))
+            .andExpect(jsonPath("$.data[1].routeCount").value(0))
+
+        mockMvc.perform(get("$baseUrl/1").with(testJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.routeCount").value(3))
+    }
+
+    @Test
     fun `POST area returns 201 with Location header`() {
         mockMvc.perform(post(baseUrl).with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content(validArea))
             .andExpect(status().isCreated)


### PR DESCRIPTION
## Summary
- Adds `routeCount` (total routes across all of an area's walls) to `ClimbingAreaResponse`, so clients can show it without fetching the full walls+routes collections.
- List endpoint batches counts for the whole page in one grouped query (`routes JOIN walls … GROUP BY area_id`) — no N+1.
- `getById`/`update` do a single-area count lookup; `create` returns 0 (a new area has no walls).

Closes #63

## Test plan
- [x] Unit: `ClimbingAreaServiceTest` — `getRouteCounts` delegates to repository
- [x] IT: `ClimbingAreaControllerIT` — count aggregates across two walls (3 routes), 0 for an area with no routes, present on both list and detail endpoints
- [x] `./gradlew test` green (Testcontainers ITs included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)